### PR TITLE
PWA install tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,8 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.
-cjadx3-codex/2025-06-06
 - La barre latérale intègre un bouton de réduction discret dans son coin supérieur droit ; l'icône passe d'une croix à un petit carré selon l'état de la barre.
-=======
 - Une option permet de désactiver les pop-ups d'information dans les préférences du profil.
-- La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.
-main
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
 - En mode PC, la barre latérale adopte un style de tuile plus sobre, sans barre de défilement.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
@@ -33,6 +29,7 @@ main
 - Les applications internes utilisent désormais uniquement les icônes Font Awesome pour un style unifié.
 - Sur mobile, l'application peut s'installer en plein écran grâce au fichier `manifest.webmanifest`.
 - Les icônes PWA ne sont pas incluses dans le dépôt pour éviter d'ajouter des fichiers binaires.
+- Une tuile d'accueil propose l'installation directe de l'application en PWA.
 
 ## Aperçu local
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,30 +1,19 @@
 # 📝 C2R OS - Journal des modifications
 
-kce102-codex/2025-06-06
 ## [1.1.6] - 2025-06-12 "SidebarTiles"
 
 ### ✨ Interface
 - La sidebar PC adopte un style de tuile plus sobre et ne comporte plus de barre de défilement.
-=======
-cjadx3-codex/2025-06-06
-## [1.1.6] - 2025-06-12 "UI"
 
 ### ✨ Améliorations du bouton de réduction
 - Le bouton de basculement de la sidebar est désormais plus discret et collé au coin supérieur droit en mode desktop.
-=======
-i9mo3r-codex/2025-06-06
-## [1.1.6] - 2025-06-12 "InfoToggle"
 
 ### ✨ Préférences
 - Possibilité de désactiver tous les pop-ups d'information depuis la page Profil.
-=======
-## [1.1.6] - 2025-06-12 "Contact"
 
 ### 📮 Formulaire de contact
 - Ajout d'une page `contact.html` pour envoyer un message depuis le navigateur.
-main
-main
-main
+- Une tuile d'accueil propose désormais l'installation de C2R OS en PWA.
 
 ## [1.1.5] - 2025-06-11 "UI Icons"
 

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -8,6 +8,7 @@ La petite croix fermant la liste déroulante des applications sur mobile adopte 
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
+Une tuile sur la page d'accueil invite l'utilisateur à installer l'application en PWA.
 
 La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page.
 Un interrupteur permet désormais de désactiver tous les pop-ups d'information depuis les préférences du profil.

--- a/index.html
+++ b/index.html
@@ -114,6 +114,12 @@
                             <h3>Configurez le système</h3>
                             <p>Accédez aux options avancées si vous disposez des droits.</p>
                         </div>
+                        <div class="card info-tile" id="install-tile" style="display:none;">
+                            <span data-icon="download"></span>
+                            <h3>Installer C2R OS</h3>
+                            <p>Ajoutez l'application à l'écran d'accueil pour un accès direct.</p>
+                            <button id="install-btn" class="btn btn-primary">Installer</button>
+                        </div>
                     </div>
 
                     <div id="daily-tip" class="daily-tip">

--- a/js/main.js
+++ b/js/main.js
@@ -141,10 +141,13 @@ function setupGlobalEventHandlers() {
     setupDragAndDrop();
     
     // Raccourcis clavier globaux
-    setupKeyboardShortcuts();
-    
-    // Configurer les gestionnaires d'authentification
-    setupAuthEventListeners();
+  setupKeyboardShortcuts();
+
+  // Configurer les gestionnaires d'authentification
+  setupAuthEventListeners();
+
+  // Gestionnaire d'installation PWA
+  setupPWAInstall();
 }
 
 /**
@@ -810,6 +813,42 @@ function clearSidebarApps() {
     if (sidebarApps) {
         sidebarApps.innerHTML = '';
     }
+}
+
+/**
+ * Configurer l'installation de la PWA via la tuile d'accueil
+ */
+let deferredInstallPrompt;
+function setupPWAInstall() {
+    const installTile = document.getElementById('install-tile');
+    const installBtn = document.getElementById('install-btn');
+
+    window.addEventListener('beforeinstallprompt', (e) => {
+        e.preventDefault();
+        deferredInstallPrompt = e;
+        if (installTile) {
+            installTile.style.display = 'block';
+        }
+    });
+
+    if (installBtn) {
+        installBtn.addEventListener('click', async () => {
+            if (!deferredInstallPrompt) return;
+            deferredInstallPrompt.prompt();
+            const { outcome } = await deferredInstallPrompt.userChoice;
+            if (outcome === 'accepted' && installTile) {
+                installTile.style.display = 'none';
+            }
+            deferredInstallPrompt = null;
+        });
+    }
+
+    window.addEventListener('appinstalled', () => {
+        if (installTile) {
+            installTile.style.display = 'none';
+        }
+        deferredInstallPrompt = null;
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix merge artifacts in docs
- add a PWA install tile on the home page
- expose installation logic in `main.js`
- document the new tile
- update changelog

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684364c7eae8832e8e2e86b0f171a88b