### PR TITLE
Augmentation barre mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode mobile, la poubelle s'affiche désormais en rouge grâce à une règle CSS dédiée.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
+- La barre de navigation mobile mesure maintenant 80px de haut pour une meilleure ergonomie.
 - Le titre du menu mobile a été retiré et les icônes y sont plus petites.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.8] - 2025-06-14 "BottomNav80"
+
+### ✨ Interface mobile
+- Barre de navigation mobile agrandie à 80px de haut.
+
 ## [1.1.7] - 2025-06-13 "MobileApps"
 
 ### ✨ Interface mobile

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -10,7 +10,7 @@
         bottom: 0;
         left: 0;
         right: 0;
-        height: 60px;
+        height: 80px;
         background-color: var(--c2r-bg-card);
         border-top: 1px solid var(--c2r-border);
         z-index: var(--z-sidebar);
@@ -45,7 +45,7 @@
 .mobile-apps-dropdown {
     display: none;
     position: fixed;
-    bottom: 60px;
+    bottom: 80px;
     left: 0;
     right: 0;
     max-height: 50vh;

--- a/css/layout.css
+++ b/css/layout.css
@@ -601,7 +601,7 @@ body.sidebar-right .sidebar {
     
     
     .main-content {
-        padding: calc(60px + var(--c2r-spacing-md)) var(--c2r-spacing-md) calc(60px + var(--c2r-spacing-md));
+        padding: calc(80px + var(--c2r-spacing-md)) var(--c2r-spacing-md) calc(80px + var(--c2r-spacing-md));
     }
     
     .page-header {
@@ -644,7 +644,7 @@ body.sidebar-right .sidebar {
 
 @media (max-width: 480px) {
     .main-content {
-        padding: calc(60px + var(--c2r-spacing-sm)) var(--c2r-spacing-sm) calc(60px + var(--c2r-spacing-sm));
+        padding: calc(80px + var(--c2r-spacing-sm)) var(--c2r-spacing-sm) calc(80px + var(--c2r-spacing-sm));
     }
     
     .welcome-card {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -7,6 +7,7 @@ La petite croix fermant la liste déroulante des applications sur mobile adopte 
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
 
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
+Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
 Une tuile sur la page d'accueil invite l'utilisateur à installer l'application en PWA.


### PR DESCRIPTION
## Notes
- tests failing: `jest` introuvable

## Summary
- étend la barre de navigation mobile à 80px et ajuste le menu déroulant
- met à jour les espacements dans `layout.css`
- précise la nouvelle hauteur dans la documentation
- ajoute l'entrée correspondante au changelog

------
https://chatgpt.com/codex/tasks/task_e_6843dfe5ad18832ea70eb0c16f55ba5c