### PR TITLE
Ajout d'un lien vers la page Contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - La liste des pop-ups indispensables figure dans [`docs/popup-readme.md`](docs/popup-readme.md).
-- Une page de contact est disponible via [`contact.html`](contact.html).
+- Une page de contact est accessible depuis la barre de navigation via [`contact.html`](contact.html).
 - La documentation de la page de contact se trouve dans [`docs/contact-readme.md`](docs/contact-readme.md).
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.8] - 2025-06-14 "ContactLink"
+
+### 📮 Lien vers la page Contact
+- Ajout d'un accès direct à `contact.html` depuis la barre de navigation.
+
 ## [1.1.7] - 2025-06-13 "MobileApps"
 
 ### ✨ Interface mobile

--- a/docs/contact-readme.md
+++ b/docs/contact-readme.md
@@ -3,3 +3,4 @@
 Ce fichier décrit la page `contact.html`.
 
 Cette page propose un formulaire basique permettant d'envoyer un message avec un nom, un email et un champ libre. Le formulaire utilise la méthode POST et peut être relié à un service de traitement. La page reprend les styles globaux de C2R OS.
+Un lien direct vers cette page est présent dans la barre de navigation.

--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
                     <span class="nav-text">Profil</span>
                 </a>
             </li>
+            <li class="nav-item">
+                <a href="contact.html" class="nav-link" aria-label="Contact">
+                    <span class="nav-icon" data-icon="mail"></span>
+                    <span class="nav-text">Contact</span>
+                </a>
+            </li>
             <li class="nav-item admin-only" style="display: none;">
                 <a href="#admin" class="nav-link" data-page="admin" aria-label="Configuration administrateur">
                     <span class="nav-icon" data-icon="admin"></span>
@@ -314,6 +320,9 @@
         </a>
         <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil">
             <span class="nav-icon" data-icon="profile"></span>
+        </a>
+        <a href="contact.html" class="nav-link" aria-label="Contact">
+            <span class="nav-icon" data-icon="mail"></span>
         </a>
         <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
             <span class="nav-icon" data-icon="list"></span>


### PR DESCRIPTION
## Résumé
- ajout d'un lien vers `contact.html` dans la barre latérale
- ajout d'un bouton Contact dans la navigation mobile
- mise à jour de la documentation pour indiquer ce nouvel accès
- mise à jour du changelog

## Tests
- `npm test` *(échoue : jest non installé)*

------
https://chatgpt.com/codex/tasks/task_e_6843e008e168832e899b9e84d789f2a8