### PR TITLE
Ajout masquage barre de recherche

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - Le titre du menu mobile a été retiré et les icônes y sont plus petites.
+- La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction discret dans son coin supérieur droit ; l'icône passe d'une croix à un petit carré selon l'état de la barre.

--- a/css/global.css
+++ b/css/global.css
@@ -56,6 +56,11 @@ p {
     font-size: var(--font-size-lg);
 }
 
+/* Utilitaire pour cacher un élément */
+.hidden {
+    display: none !important;
+}
+
 /* Boutons */
 .btn {
     display: inline-flex;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -6,6 +6,7 @@ Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour
 La petite croix fermant la liste déroulante des applications sur mobile adopte elle aussi une teinte neutre.
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
 
+La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.

--- a/js/main.js
+++ b/js/main.js
@@ -148,6 +148,23 @@ function setupGlobalEventHandlers() {
 
   // Gestionnaire d'installation PWA
   setupPWAInstall();
+
+  // Masquer la barre de recherche lors du défilement
+  const storePage = document.getElementById('page-store');
+  const searchContainer = storePage?.querySelector('.search-container');
+  if (storePage && searchContainer) {
+    let lastScrollTop = 0;
+    window.addEventListener('scroll', () => {
+      if (!storePage.classList.contains('active')) return;
+      const st = window.pageYOffset || document.documentElement.scrollTop;
+      if (st > lastScrollTop && st > 50) {
+        searchContainer.classList.add('hidden');
+      } else {
+        searchContainer.classList.remove('hidden');
+      }
+      lastScrollTop = st <= 0 ? 0 : st;
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Notes
- impossibilite d'executer `npm test` : `jest` absent

## Summary
- ajout d'une classe `.hidden` dans `global.css`
- masquage de la barre de recherche du Store au defilement via `main.js`
- mise a jour de la documentation

## Testing
- `npm test` *(echec : jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e0abff5c832e842097f09df2e303