### PR TITLE
Harmonisation des icônes du menu mobile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@
 ### ✨ Interface mobile
 - Barre de navigation mobile agrandie à 80px de haut.
 
+## [1.1.9] - 2025-06-15 "MobileIcons"
+
+### ✨ Interface mobile
+- Icônes du menu mobile alignées sur celles de la page Profil.
+
 ## [1.1.7] - 2025-06-13 "MobileApps"
 
 ### ✨ Interface mobile

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -96,7 +96,7 @@
 }
 
 .mobile-app-item .app-icon {
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-md);
     min-width: 20px;
     text-align: center;
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -10,6 +10,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
+Les icônes du menu mobile reprennent la même taille que celles utilisées dans la page Profil pour une cohérence visuelle.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
 Une tuile sur la page d'accueil invite l'utilisateur à installer l'application en PWA.


### PR DESCRIPTION
## Notes
- jest n'est pas installé dans l'environnement, les tests n'ont pas pu être lancés.

## Summary
- réduit la taille des icônes de la liste d'applications mobile
- documentation mise à jour pour l'ajout de cette harmonisation
- changelog mis à jour


------
https://chatgpt.com/codex/tasks/task_e_68444faeb46c832ea330ee9ca9af08e3