### PR TITLE
Réduction des icônes du menu mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - La barre de navigation mobile mesure maintenant 80px de haut pour une meilleure ergonomie.
-- Le titre du menu mobile a été retiré et les icônes y sont plus petites.
+- Le titre du menu mobile a été retiré et les icônes sont encore plus petites pour gagner de la place.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@
 ### ✨ Interface mobile
 - Icônes du menu mobile alignées sur celles de la page Profil.
 
+## [1.1.10] - 2025-06-16 "MobileIconsSmall"
+
+### ✨ Interface mobile
+- Icônes du menu mobile encore réduites pour économiser de l'espace.
+
 ## [1.1.7] - 2025-06-13 "MobileApps"
 
 ### ✨ Interface mobile

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -96,8 +96,8 @@
 }
 
 .mobile-app-item .app-icon {
-    font-size: var(--font-size-md);
-    min-width: 20px;
+    font-size: var(--font-size-sm);
+    min-width: 16px;
     text-align: center;
 }
 

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -10,7 +10,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
-Les icônes du menu mobile reprennent la même taille que celles utilisées dans la page Profil pour une cohérence visuelle.
+Les icônes du menu mobile sont désormais plus petites afin d'optimiser l'espace disponible.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
 Une tuile sur la page d'accueil invite l'utilisateur à installer l'application en PWA.


### PR DESCRIPTION
## Notes
- tests échouent car Jest est absent dans l'environnement

## Summary
- réduit la taille des icônes dans le menu mobile
- ajuste la documentation sur l'interface utilisateur
- met à jour le changelog
- précise le changement dans le README

------
https://chatgpt.com/codex/tasks/task_e_68446c0d30f8832eb461d37e37ff9d4e