### PR TITLE
Fix mobile dropdown closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode mobile, la poubelle s'affiche désormais en rouge grâce à une règle CSS dédiée.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
+- En mode mobile, la liste des applications se referme si l'on touche un autre bouton de la barre.
 - La barre de navigation mobile mesure maintenant 80px de haut pour une meilleure ergonomie.
 - Le titre du menu mobile a été retiré et les icônes y sont plus petites.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -10,6 +10,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
+Lorsque l'on presse un autre bouton de cette barre, la liste d'applications se referme automatiquement.
 Les icônes du menu mobile reprennent la même taille que celles utilisées dans la page Profil pour une cohérence visuelle.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.

--- a/js/bottom-nav.js
+++ b/js/bottom-nav.js
@@ -19,6 +19,13 @@ class BottomNav {
             this.closeBtn.addEventListener('click', () => this.closeMenu());
         }
 
+        // Fermer le menu si l'utilisateur appuie sur un autre bouton de navigation
+        document.querySelectorAll('.bottom-nav .nav-link').forEach(link => {
+            if (link !== this.appsBtn) {
+                link.addEventListener('click', () => this.closeMenu());
+            }
+        });
+
         if (this.dropdown) {
             this.dropdown.addEventListener('click', (e) => {
                 if (e.target === this.dropdown) {


### PR DESCRIPTION
## Summary
- close app dropdown when navigating to another tab
- document that the dropdown closes on navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446c4876a8832eb3f87bb2c72d2e35