### PR TITLE
Ajout de tuiles explicatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
 - En mode PC, la barre latérale adopte un style de tuile plus sobre, sans barre de défilement.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
-- La page d'accueil présente des tuiles explicatives pour découvrir le fonctionnement du site.
+- La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
+  1. **Installez des applications IA et services** — un lien mène directement au Store et les applications installées apparaissent dans la barre de navigation.
+  2. **Options du profil** — accès rapide pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.
+  3. **Installer C2R OS** — un bouton permet d'ajouter l'application sur smartphone en mode PWA.
+  4. **Infos sur les applications** — un lien renvoie au Store pour découvrir les différents types d'apps disponibles.
 - Les applications internes utilisent désormais uniquement les icônes Font Awesome pour un style unifié.
 - Sur mobile, l'application peut s'installer en plein écran grâce au fichier `manifest.webmanifest`.
 - Les icônes PWA ne sont pas incluses dans le dépôt pour éviter d'ajouter des fichiers binaires.

--- a/docs/profile-readme.md
+++ b/docs/profile-readme.md
@@ -11,4 +11,4 @@ mobile se mettent automatiquement à jour pour refléter ce nouvel ordre. Lors d
 déplacement, l'application en cours de glisse est légèrement agrandie et son
 fond s'assombrit pour mieux la distinguer.
 Un bouton de déconnexion est disponible pour terminer la session.
-Les préférences incluent une option pour masquer toutes les notifications et autres pop-ups d'information.
+Les préférences incluent plusieurs options : activer ou désactiver les notifications, choisir le mode sombre et déplacer la barre de navigation.

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -13,7 +13,11 @@ Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navig
 Les icônes du menu mobile reprennent la même taille que celles utilisées dans la page Profil pour une cohérence visuelle.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
-Une tuile sur la page d'accueil invite l'utilisateur à installer l'application en PWA.
+Une série de tuiles d'accueil explique comment utiliser l'OS :
+1. **Installez des applications IA et services** avec un lien direct vers le Store.
+2. **Options du profil** pour gérer les notifications, le thème sombre ou la position de la barre de navigation.
+3. **Installer C2R OS** en mode PWA sur smartphone.
+4. **Infos sur les applications** menant au catalogue complet.
 
 La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page.
 Un interrupteur permet désormais de désactiver tous les pop-ups d'information depuis les préférences du profil.

--- a/index.html
+++ b/index.html
@@ -101,24 +101,27 @@
                     <div class="info-tiles">
                         <div class="card info-tile">
                             <span data-icon="store"></span>
-                            <h3>Installez des applications</h3>
-                            <p>Parcourez le Store pour ajouter de nouvelles fonctionnalités.</p>
+                            <h3>Installez des applications IA et services</h3>
+                            <p>Explorez le Store pour trouver des intelligences artificielles, des formations ou des services. Les applications installées apparaissent ensuite dans la barre de navigation.</p>
+                            <a href="#store" class="btn btn-secondary">Aller au Store</a>
                         </div>
                         <div class="card info-tile">
                             <span data-icon="profile"></span>
-                            <h3>Personnalisez votre profil</h3>
-                            <p>Modifiez vos préférences et gérez vos applications installées.</p>
-                        </div>
-                        <div class="card info-tile">
-                            <span data-icon="admin"></span>
-                            <h3>Configurez le système</h3>
-                            <p>Accédez aux options avancées si vous disposez des droits.</p>
+                            <h3>Options du profil</h3>
+                            <p>Activez ou désactivez les notifications, changez de thème et déplacez la barre de navigation.</p>
+                            <a href="#profile" class="btn btn-secondary">Ouvrir le profil</a>
                         </div>
                         <div class="card info-tile" id="install-tile" style="display:none;">
                             <span data-icon="download"></span>
                             <h3>Installer C2R OS</h3>
-                            <p>Ajoutez l'application à l'écran d'accueil pour un accès direct.</p>
+                            <p>Ajoutez l'application sur votre smartphone en mode PWA pour un accès direct.</p>
                             <button id="install-btn" class="btn btn-primary">Installer</button>
+                        </div>
+                        <div class="card info-tile">
+                            <span data-icon="info"></span>
+                            <h3>Infos sur les applications</h3>
+                            <p>Découvrez les différents types d'applications disponibles et accédez directement au catalogue.</p>
+                            <a href="#store" class="btn btn-secondary">Catalogue complet</a>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- enrichir la page d'accueil avec des tuiles d'aide
- mettre à jour la documentation utilisateur et UI
- préciser les options du profil

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_68446ddfb3c0832eb2faf84037d73e76