### PR TITLE
Accueil : tuiles cliquables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode PC, la barre latérale adopte un style de tuile plus sobre, sans barre de défilement.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
-  1. **Installez des applications IA et services** — un lien mène directement au Store et les applications installées apparaissent dans la barre de navigation.
-  2. **Options du profil** — accès rapide pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.
+  1. **Installez des applications IA et services** — la tuile elle-même mène directement au Store et les applications installées apparaissent dans la barre de navigation.
+  2. **Options du profil** — la tuile ouvre directement la page correspondante pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.
   3. **Installer C2R OS** — un bouton permet d'ajouter l'application sur smartphone en mode PWA.
-  4. **Infos sur les applications** — un lien renvoie au Store pour découvrir les différents types d'apps disponibles.
+  4. **Infos sur les applications** — cette tuile renvoie directement au Store pour découvrir les différents types d'apps disponibles.
 - Les applications internes utilisent désormais uniquement les icônes Font Awesome pour un style unifié.
 - Sur mobile, l'application peut s'installer en plein écran grâce au fichier `manifest.webmanifest`.
 - Les icônes PWA ne sont pas incluses dans le dépôt pour éviter d'ajouter des fichiers binaires.

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -13,11 +13,11 @@ Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navig
 Les icônes du menu mobile sont désormais plus petites afin d'optimiser l'espace disponible.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
-Une série de tuiles d'accueil explique comment utiliser l'OS :
-1. **Installez des applications IA et services** avec un lien direct vers le Store.
-2. **Options du profil** pour gérer les notifications, le thème sombre ou la position de la barre de navigation.
+Une série de tuiles d'accueil explique comment utiliser l'OS :
+1. **Installez des applications IA et services** — la tuile entière mène directement au Store.
+2. **Options du profil** — la tuile ouvre directement la page correspondante pour gérer les notifications, le thème sombre ou la position de la barre de navigation.
 3. **Installer C2R OS** en mode PWA sur smartphone.
-4. **Infos sur les applications** menant au catalogue complet.
+4. **Infos sur les applications** — cette tuile renvoie directement au catalogue complet du Store.
 
 La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page.
 Un interrupteur permet désormais de désactiver tous les pop-ups d'information depuis les préférences du profil.

--- a/index.html
+++ b/index.html
@@ -99,30 +99,27 @@
                     </div>
 
                     <div class="info-tiles">
-                        <div class="card info-tile">
+                        <a href="#store" data-page="store" class="card info-tile">
                             <span data-icon="store"></span>
                             <h3>Installez des applications IA et services</h3>
                             <p>Explorez le Store pour trouver des intelligences artificielles, des formations ou des services. Les applications installées apparaissent ensuite dans la barre de navigation.</p>
-                            <a href="#store" class="btn btn-secondary">Aller au Store</a>
-                        </div>
-                        <div class="card info-tile">
+                        </a>
+                        <a href="#profile" data-page="profile" class="card info-tile">
                             <span data-icon="profile"></span>
                             <h3>Options du profil</h3>
                             <p>Activez ou désactivez les notifications, changez de thème et déplacez la barre de navigation.</p>
-                            <a href="#profile" class="btn btn-secondary">Ouvrir le profil</a>
-                        </div>
+                        </a>
                         <div class="card info-tile" id="install-tile" style="display:none;">
                             <span data-icon="download"></span>
                             <h3>Installer C2R OS</h3>
                             <p>Ajoutez l'application sur votre smartphone en mode PWA pour un accès direct.</p>
                             <button id="install-btn" class="btn btn-primary">Installer</button>
                         </div>
-                        <div class="card info-tile">
+                        <a href="#store" data-page="store" class="card info-tile">
                             <span data-icon="info"></span>
                             <h3>Infos sur les applications</h3>
                             <p>Découvrez les différents types d'applications disponibles et accédez directement au catalogue.</p>
-                            <a href="#store" class="btn btn-secondary">Catalogue complet</a>
-                        </div>
+                        </a>
                     </div>
 
                     <div id="daily-tip" class="daily-tip">


### PR DESCRIPTION
## Notes
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Summary
- transformé les tuiles de l'accueil en liens directs vers le store et le profil
- mis à jour la tuile « Infos sur les applications » pour pointer directement sur le catalogue
- documenté la navigation par tuiles dans README.md et `docs/ui-readme.md`

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_68447bda80f4832eb93a0511cbfebb36