### PR TITLE
Amélioration icônes minimalistes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - La barre de navigation mobile mesure maintenant 80px de haut pour une meilleure ergonomie.
 - Le titre du menu mobile a été retiré et les icônes sont encore plus petites pour gagner de la place.
+- Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.11] - 2025-06-17 "MobileIconsGrey"
+
+### ✨ Interface mobile
+- Les icônes de la liste déroulante des applications sont grisées pour un rendu minimaliste.
 ## [1.1.8] - 2025-06-14 "BottomNav80"
 
 ### ✨ Interface mobile

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -99,6 +99,7 @@
     font-size: var(--font-size-sm);
     min-width: 16px;
     text-align: center;
+    color: var(--c2r-text-muted);
 }
 
 .mobile-app-item:last-child {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -11,6 +11,7 @@ La barre de recherche du Store se masque automatiquement lors du défilement ver
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
 Les icônes du menu mobile sont désormais plus petites afin d'optimiser l'espace disponible.
+Les pictogrammes de la liste déroulante adoptent maintenant un gris neutre pour un aspect minimaliste.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
 Une série de tuiles d'accueil explique comment utiliser l'OS :


### PR DESCRIPTION
## Notes
Les icônes du menu mobile ont été rendues plus discrètes pour respecter le style minimaliste demandé.

## Summary
- style minimaliste sur les icônes de la liste mobile
- mise à jour du README et de la documentation UI
- ajout d'une entrée de changelog

## Testing
- `npm test` *(échoue : jest indisponible)*

------
https://chatgpt.com/codex/tasks/task_e_68447c222eec832ebad5b297e71ba3ed