### PR TITLE
Ajout du retour haptique lors du déplacement des apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
+- Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction discret dans son coin supérieur droit ; l'icône passe d'une croix à un petit carré selon l'état de la barre.
 - Une option permet de désactiver les pop-ups d'information dans les préférences du profil, ce qui masque toutes les notifications du système.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.12] - 2025-06-18 "DragVibrate"
+
+### ✨ Interface mobile
+- Vibration courte lors du déplacement des applications dans la page Profil.
 ## [1.1.11] - 2025-06-17 "MobileIconsGrey"
 
 ### ✨ Interface mobile

--- a/docs/profile-readme.md
+++ b/docs/profile-readme.md
@@ -9,6 +9,7 @@ la page Profil. L'ordre choisi est sauvegardé et fonctionne aussi bien sur
 mobile que sur ordinateur grâce à SortableJS. La barre latérale et le menu
 mobile se mettent automatiquement à jour pour refléter ce nouvel ordre. Lors du
 déplacement, l'application en cours de glisse est légèrement agrandie et son
-fond s'assombrit pour mieux la distinguer.
+fond s'assombrit pour mieux la distinguer. Sur smartphone, une courte vibration
+signale le début et la fin du déplacement.
 Un bouton de déconnexion est disponible pour terminer la session.
 Les préférences incluent plusieurs options : activer ou désactiver les notifications, choisir le mode sombre et déplacer la barre de navigation.

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -20,8 +20,8 @@ Une série de tuiles d'accueil explique comment utiliser l'OS :
 3. **Installer C2R OS** en mode PWA sur smartphone.
 4. **Infos sur les applications** — cette tuile renvoie directement au catalogue complet du Store.
 
-La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page.
-Un interrupteur permet désormais de désactiver tous les pop-ups d'information depuis les préférences du profil.
+ La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page. Sur smartphone, une vibration courte marque le début et la fin du déplacement.
+ Un interrupteur permet désormais de désactiver tous les pop-ups d'information depuis les préférences du profil.
 
 La sidebar propose un mode compact activé par un petit bouton discret situé dans le coin supérieur droit. L'icône passe d'une croix à un petit carré lorsque la barre est repliée, quelle que soit la position de la barre ou le thème. Le bouton utilise un gris légèrement plus sombre que la sidebar pour rester visible sans attirer l'œil. Les icônes de suppression demeurent rouges comme en mode standard.
 

--- a/js/main.js
+++ b/js/main.js
@@ -446,9 +446,15 @@ function setupDragAndDrop() {
         animation: 150,
         onStart: (evt) => {
             evt.item.classList.add('dragging');
+            if (navigator.vibrate) {
+                navigator.vibrate(30);
+            }
         },
         onEnd: (evt) => {
             evt.item.classList.remove('dragging');
+            if (navigator.vibrate) {
+                navigator.vibrate(50);
+            }
             const order = Array.from(list.querySelectorAll('.app-item'))
                 .map(item => item.dataset.appId);
             window.C2R_SYSTEM?.appCore.reorderApps(order);


### PR DESCRIPTION
## Notes
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Summary
- ajoute des vibrations courtes au début et à la fin du glisser-déposer
- documente cette amélioration dans `profile-readme.md` et `ui-readme.md`
- mentionne la nouveauté dans le README principal
- met à jour le changelog avec la version 1.1.12

## Testing
- `npm test` *(échoue : jest non installé)*

------
https://chatgpt.com/codex/tasks/task_e_6844b0b1e504832eb736082d6cb2c620