### PR TITLE
feat: menu apps aligné à droite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.12] - 2025-06-18 "MobileMenuCompact"
+
+### ✨ Interface mobile
+- Menu des applications repensé : largeur réduite et suppression du bouton de fermeture.
+- Icônes et pictogrammes encore plus petits pour un style minimaliste.
+- Le menu est désormais aligné à droite sur mobile et ses icônes sont minuscules.
 ## [1.1.11] - 2025-06-17 "MobileIconsGrey"
 
 ### ✨ Interface mobile

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -19,7 +19,7 @@
     }
 
     .bottom-nav .nav-icon {
-        font-size: var(--font-size-lg);
+        font-size: var(--font-size-md);
     }
 
     .bottom-nav .nav-link {
@@ -46,13 +46,13 @@
     display: none;
     position: fixed;
     bottom: 80px;
-    left: 0;
-    right: 0;
+    left: auto;
+    right: 10%;
+    width: 80%;
     max-height: 50vh;
     background-color: var(--c2r-bg-card);
-    border-top: 1px solid var(--c2r-border);
-    border-left: 1px solid var(--c2r-border);
-    border-right: 1px solid var(--c2r-border);
+    border: 1px solid var(--c2r-border);
+    border-radius: var(--c2r-radius);
     overflow-y: auto;
     z-index: calc(var(--z-sidebar) + 1);
 }
@@ -96,7 +96,7 @@
 }
 
 .mobile-app-item .app-icon {
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xxs);
     min-width: 16px;
     text-align: center;
     color: var(--c2r-text-muted);

--- a/css/theme.css
+++ b/css/theme.css
@@ -30,6 +30,7 @@
     --c2r-transition-fast: all 0.15s ease;
     
     /* Tailles de police */
+    --font-size-xxs: 10px;
     --font-size-xs: 12px;
     --font-size-sm: 14px;
     --font-size-md: 16px;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -4,14 +4,15 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
 Lorsqu'un utilisateur tente d'installer une application sans être connecté, une notification indique désormais « Veuillez vous connecter pour installer ».
-La petite croix fermant la liste déroulante des applications sur mobile adopte elle aussi une teinte neutre.
+La liste déroulante des applications se ferme désormais en appuyant hors du menu ; la petite croix a été supprimée.
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
-Les icônes du menu mobile sont désormais plus petites afin d'optimiser l'espace disponible.
+Les icônes du menu mobile sont encore plus petites afin d'optimiser l'espace disponible.
 Les pictogrammes de la liste déroulante adoptent maintenant un gris neutre pour un aspect minimaliste.
+La largeur du menu est réduite et le bloc est aligné sur la droite afin d'optimiser l'espace sur petits écrans.
 L'ajout d'un fichier `manifest.webmanifest` permet d'installer C2R OS en plein écran sur mobile.
 Les icônes nécessaires à la PWA sont chargées dynamiquement afin d'éviter tout fichier binaire dans le dépôt.
 Une série de tuiles d'accueil explique comment utiliser l'OS :

--- a/index.html
+++ b/index.html
@@ -321,9 +321,6 @@
     </nav>
 
     <div class="mobile-apps-dropdown" id="mobile-apps-dropdown">
-        <div class="mobile-apps-header">
-            <button class="close-btn" id="close-mobile-apps" aria-label="Fermer">&times;</button>
-        </div>
         <div class="mobile-apps-list" id="mobile-apps-list"></div>
     </div>
 

--- a/js/bottom-nav.js
+++ b/js/bottom-nav.js
@@ -3,7 +3,6 @@ class BottomNav {
     constructor() {
         this.dropdown = document.getElementById('mobile-apps-dropdown');
         this.appsBtn = document.getElementById('mobile-apps-btn');
-        this.closeBtn = document.getElementById('close-mobile-apps');
         this.init();
     }
 
@@ -13,10 +12,6 @@ class BottomNav {
                 e.preventDefault();
                 this.toggleMenu();
             });
-        }
-
-        if (this.closeBtn) {
-            this.closeBtn.addEventListener('click', () => this.closeMenu());
         }
 
         if (this.dropdown) {

--- a/js/ui-minimal-red.js
+++ b/js/ui-minimal-red.js
@@ -114,21 +114,12 @@ class UIMinimalRed {
         dropdown.id = 'mobile-apps-dropdown';
         dropdown.className = 'mobile-apps-dropdown';
         dropdown.innerHTML = `
-            <div class="mobile-apps-header">
-                <button class="close-btn" id="close-mobile-apps" aria-label="Fermer">&times;</button>
-            </div>
             <div class="mobile-apps-list" id="mobile-apps-list">
                 <!-- Applications générées dynamiquement -->
             </div>
         `;
         
         document.body.appendChild(dropdown);
-        
-        // Événement fermeture
-        document.getElementById('close-mobile-apps').addEventListener('click', () => {
-            this.closeMobileAppsMenu();
-        });
-        
         // Fermeture en cliquant à l'extérieur
         dropdown.addEventListener('click', (e) => {
             if (e.target === dropdown) {


### PR DESCRIPTION
## Summary
- ajuster la largeur et l'alignement du menu mobile sur la droite
- définir une taille de police `--font-size-xxs` et l'appliquer aux icônes du menu
- documenter la nouvelle position à droite et la taille minuscule des icônes

## Testing
- `npm test` *(échoue : jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844afeac8e0832eb4ad69a6240c8cfb