### PR TITLE
Mise en place du thème sombre rouge pour le Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Le titre du menu mobile a été retiré et les icônes sont encore plus petites pour gagner de la place.
 - Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
+- Le Store adopte un mode sombre rouge : fond #0d0d12 dégradé, cartes 300×220 px et boutons « + » cerclés. La police Montserrat est utilisée pour cette section.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -1,0 +1,114 @@
+/* Styles dark mode pour le Store C2R */
+
+body.theme-dark {
+    background: radial-gradient(circle at top left, #0d0d12, #15151b);
+    font-family: 'Montserrat', 'Inter', sans-serif;
+}
+
+#page-store {
+    color: #ffffff;
+    font-family: 'Montserrat', 'Inter', sans-serif;
+}
+
+#page-store .apps-grid {
+    justify-content: center;
+}
+
+#page-store .app-card {
+    width: 300px;
+    height: 220px;
+    background: #1a1a21;
+    border-radius: 16px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    transition: all 180ms ease-in-out;
+    display: flex;
+    flex-direction: column;
+    padding: 24px;
+}
+
+#page-store .app-card:hover {
+    background: linear-gradient(#1e1e26, #23232b);
+}
+
+#page-store .app-icon .icon {
+    font-size: 48px;
+    color: #c53a3a;
+    transition: all 180ms ease-in-out;
+}
+
+#page-store .app-card:hover .app-icon .icon {
+    color: #ff5858;
+}
+
+#page-store .app-card:active .app-icon .icon {
+    color: rgba(255, 88, 88, 0.15);
+}
+
+#page-store .badge-category {
+    background-color: #26262f;
+    color: #b7b7c0;
+    padding: 2px 6px;
+    border-radius: 8px;
+    font-size: 12px;
+}
+
+#page-store .app-actions {
+    margin-top: auto;
+    display: flex;
+    justify-content: center;
+}
+
+#page-store .app-toggle-btn {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid #2a2a32;
+    background: #15151b;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 180ms ease-in-out;
+}
+
+#page-store .app-toggle-btn .icon {
+    font-size: 18px;
+    color: #c53a3a;
+    transition: all 180ms ease-in-out;
+}
+
+#page-store .app-toggle-btn:hover {
+    background: radial-gradient(circle at center, #c53a3a, #ff5858);
+    transform: translateY(-2px) scale(1.05);
+}
+
+#page-store .app-toggle-btn:hover .icon {
+    color: #ffffff;
+}
+
+#page-store .app-toggle-btn:active {
+    background: #ff5858;
+    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.55);
+}
+
+#page-store .app-toggle-btn:active .icon {
+    color: #ffffff;
+}
+
+#page-store .search-container input,
+#page-store select {
+    background: #121218;
+    border: 1px solid #2a2a32;
+    border-radius: 10px;
+    color: #ffffff;
+    font-family: 'Montserrat', 'Inter', sans-serif;
+}
+
+#page-store .search-container input::placeholder {
+    color: #5e5e66;
+}
+
+#page-store .search-icon .icon {
+    color: #b7b7c0;
+    transition: all 180ms ease-in-out;
+}

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -9,6 +9,7 @@ La liste déroulante des applications se ferme désormais en appuyant hors du me
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
+Le Store utilise désormais un thème sombre rouge : fond #0d0d12 en dégradé, cartes 300×220 px et boutons « + » animés. Tout le texte emploie la police Montserrat.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
 Lorsque l'on presse un autre bouton de cette barre, la liste d'applications se referme automatiquement.

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/store-dark.css">
 </head>
 <body class="theme-dark">
     <!-- Navigation latérale -->

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -281,7 +281,7 @@ class UICore {
                     </div>
                 </div>
                 <div class="app-meta text-small text-muted">
-                    <span>Catégorie: ${app.category}</span>
+                    <span class="badge-category">${app.category}</span>
                     <span>Date: ${app.version}</span>
                     <span>Taille: ${app.size}</span>
                 </div>


### PR DESCRIPTION
## Summary
- ajout d'un fichier `store-dark.css` pour le style dédié au Store
- intégration de la police Montserrat et de cette feuille dans `index.html`
- affichage de la catégorie via un badge dans les cartes
- documentation mise à jour avec le nouveau thème

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_6844c563f894832e83d5dee2543fe626