### PR TITLE
Mise à jour palette couleur

### DIFF
--- a/apps/htmlformatter/app.js
+++ b/apps/htmlformatter/app.js
@@ -151,8 +151,8 @@ function createFullHTML(html, css) {
         
         /* Styles par défaut pour une meilleure présentation */
         body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; }
-        .btn { padding: 8px 16px; background: #E53935; color: white; border: none; border-radius: 4px; cursor: pointer; }
-        .btn:hover { background: #F74B45; }
+        .btn { padding: 8px 16px; background: #C53A3A; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        .btn:hover { background: #FF5858; }
         .form-group { margin-bottom: 15px; }
         .form-group label { display: block; margin-bottom: 5px; font-weight: bold; }
         .form-group input, .form-group textarea { width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; }

--- a/css/theme.css
+++ b/css/theme.css
@@ -2,9 +2,9 @@
 
 :root {
     /* Couleurs principales */
-    --c2r-accent: #E53935;
-    --c2r-accent-hover: #F74B45;
-    --c2r-accent-light: #FF7669;
+    --c2r-accent: #C53A3A;
+    --c2r-accent-hover: #FF5858;
+    --c2r-accent-light: #FF5858;
 
     /* Alias pour la coloration des icônes */
     --primary-color: var(--c2r-accent);
@@ -55,24 +55,24 @@
 
 /* Thème sombre (par défaut) */
 .theme-dark {
-    --c2r-bg: #181818;
-    --c2r-bg-secondary: #1F1F1F;
-    --c2r-bg-tertiary: #222222;
-    --c2r-bg-card: #1F1F1F;
-    --c2r-bg-hover: #222222;
-    --c2r-bg-active: #2a2a2a;
-    
-    --c2r-text: #F5F5F5;
-    --c2r-text-secondary: #B0B0B0;
-    --c2r-text-muted: #999999;
-    --c2r-text-disabled: #666666;
-    
-    --c2r-border: #333333;
-    --c2r-border-light: #444444;
+    --c2r-bg: #0D0D12;
+    --c2r-bg-secondary: #15151B;
+    --c2r-bg-tertiary: #15151B;
+    --c2r-bg-card: #15151B;
+    --c2r-bg-hover: #26262F;
+    --c2r-bg-active: #26262F;
+
+    --c2r-text: #FFFFFF;
+    --c2r-text-secondary: #B7B7C0;
+    --c2r-text-muted: #5E5E66;
+    --c2r-text-disabled: #5E5E66;
+
+    --c2r-border: #2A2A32;
+    --c2r-border-light: #2A2A32;
     --c2r-border-focus: var(--c2r-accent);
     
-    --c2r-input-bg: #1a1a1a;
-    --c2r-input-border: #333333;
+    --c2r-input-bg: #15151B;
+    --c2r-input-border: #2A2A32;
     --c2r-input-focus: var(--c2r-accent);
     
     --c2r-success: #22c55e;

--- a/docs/icon-workflow.md
+++ b/docs/icon-workflow.md
@@ -2,7 +2,7 @@
 
 Ce document décrit le processus complet de gestion des icônes entre l'équipe Design (Figma) et l'équipe Développement (INIA)
 
-Ce mini-OS suit le thème "Minimal Red" : fonds gris sombre (#181818 → #222222) avec un accent rouge (#E53935) et la police "Inter Variable".
+Ce mini-OS suit le thème "Minimal Red" : fonds sombres (#0D0D12 → #15151B) avec un accent rouge (#C53A3A) et la police "Inter Variable".
 
 ## 1. Gestion des icônes
 
@@ -83,7 +83,7 @@ Les fichiers CSS actuels (`css/`) et JS vanilla (`js/`) restent pour l'ancienne 
 - **Tests** : linting ESLint + tests unitaires Jest pour les composants.
 - **Accessibilité** :
   - Fournir un `aria-label` ou `title` explicite pour chaque icône utilisée seule.
-  - Veiller au contraste couleurs (rouge #E53935 sur fond sombre #181818/#222222).
+  - Veiller au contraste couleurs (rouge #C53A3A sur fond sombre #0D0D12/#15151B).
   - Utiliser `role="img"` sur les icônes personnalisées SVG si nécessaire.
   - Vérifier la lisibilité de la police Inter Variable sur tous les supports.
 

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -2,6 +2,20 @@
 
 S'occupe du thème, de la navigation et des notifications. Il adapte l'interface aux différents écrans et applique les préférences de l'utilisateur. C'est lui qui met à jour la sidebar et les pages lors des interactions.
 
+## Palette de couleurs
+
+| Rôle | Code |
+|------|------|
+| Rouge principal (accent) | `#C53A3A` |
+| Rouge hover / actif | `#FF5858` |
+| Blanc (texte inversé, icônes actives) | `#FFFFFF` |
+| Noir profond (fond corps) | `#0D0D12` |
+| Noir/gris foncé (zones, cartes) | `#15151B` |
+| Gris moyen (bordures, séparateurs) | `#2A2A32` |
+| Gris badge / conteneur sélectionné | `#26262F` |
+| Gris clair (texte secondaire) | `#B7B7C0` |
+| Gris placeholder (inputs) | `#5E5E66` |
+
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
 Lorsqu'un utilisateur tente d'installer une application sans être connecté, une notification indique désormais « Veuillez vous connecter pour installer ».
 Un bref retour tactile confirme aussi l'installation ou la désinstallation sur les appareils compatibles.

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -3,6 +3,6 @@
   "short_name": "C2R",
   "start_url": "./index.html",
   "display": "standalone",
-  "background_color": "#181818",
-  "theme_color": "#181818"
+  "background_color": "#0D0D12",
+  "theme_color": "#0D0D12"
 }


### PR DESCRIPTION
## Notes
Les tests Jest ne se lancent pas car les dépendances ne sont pas installées dans cet environnement.

## Summary
- thème CSS mis à jour avec la nouvelle palette
- manifeste web et app HTMLFormatter adaptés
- documentation sur la palette ajoutée dans `ui-readme.md`
- workflow des icônes mis à jour

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_6844c71bc16c832ebd4afbee73cc4fb1