### PR TITLE
Mise à jour du thème sombre du Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Le titre du menu mobile a été retiré et les icônes sont encore plus petites pour gagner de la place.
 - Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
-- Le Store adopte un mode sombre rouge : fond #0d0d12 dégradé, cartes 300×220 px et boutons « + » cerclés. La police Montserrat est utilisée pour cette section.
+- Le Store adopte un mode sombre rouge : fond #0D0D12 avec dégradé radial #15151B, cartes 280×220 px et bouton d’action en bas à droite. La police Montserrat est utilisée pour cette section.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -8,22 +8,42 @@ body.theme-dark {
 #page-store {
     color: #ffffff;
     font-family: 'Montserrat', 'Inter', sans-serif;
+    display: flex;
+    flex-direction: column;
+    padding: 40px 64px;
+}
+
+#page-store .store-controls {
+    display: flex;
+    gap: 16px;
+    margin-left: auto;
 }
 
 #page-store .apps-grid {
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 32px;
 }
 
 #page-store .app-card {
-    width: 300px;
+    width: 280px;
     height: 220px;
+    position: relative;
     background: #1a1a21;
+    border: 1px solid #2a2a32;
     border-radius: 16px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
-    transition: all 180ms ease-in-out;
+    padding: 24px 24px 56px;
+    transition: background 180ms ease;
     display: flex;
     flex-direction: column;
-    padding: 24px;
+}
+
+#page-store .app-icon {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 #page-store .app-card:hover {
@@ -34,6 +54,18 @@ body.theme-dark {
     font-size: 48px;
     color: #c53a3a;
     transition: all 180ms ease-in-out;
+}
+
+#page-store .app-info h3 {
+    font-size: 18px;
+    font-weight: 700;
+    color: #ffffff;
+    margin-top: 12px;
+}
+
+#page-store .app-info p {
+    font-size: 14px;
+    color: #b7b7c0;
 }
 
 #page-store .app-card:hover .app-icon .icon {
@@ -48,13 +80,16 @@ body.theme-dark {
     background-color: #26262f;
     color: #b7b7c0;
     padding: 2px 6px;
-    border-radius: 8px;
+    border-radius: 4px;
     font-size: 12px;
 }
 
 #page-store .app-actions {
-    margin-top: auto;
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
     display: flex;
+    align-items: center;
     justify-content: center;
 }
 
@@ -68,6 +103,7 @@ body.theme-dark {
     display: flex;
     align-items: center;
     justify-content: center;
+    color: #c53a3a;
     transition: all 180ms ease-in-out;
 }
 
@@ -89,6 +125,10 @@ body.theme-dark {
 #page-store .app-toggle-btn:active {
     background: #ff5858;
     box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.55);
+}
+
+#page-store .app-toggle-btn:focus {
+    outline: 2px solid #ff5858;
 }
 
 #page-store .app-toggle-btn:active .icon {

--- a/docs/dark-mode-rouge.md
+++ b/docs/dark-mode-rouge.md
@@ -1,0 +1,56 @@
+Store C2R – UI dark-mode rouge »
+Palette
+– Fond global : #0D0D12 → radial #15151B.
+– Rouge accent : #C53A3A, hover #FF5858.
+– Texte prim. : #FFFFFF | Texte sec. : #B7B7C0.
+– Gris cartes : #1A1A21, bord 1 px #2A2A32.
+
+Layout général
+display:flex; flex-direction:column; padding:40px 64px;
+Barre d’outils (recherche + filtres) alignée à droite : display:flex; gap:16px;
+
+Grille des cartes
+```css
+.grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(280px,1fr));
+  gap:32px;
+}
+```
+Carte application
+```css
+.card {
+  width:280px; height:220px; position:relative;
+  background:#1A1A21; border:1px solid #2A2A32; border-radius:16px;
+  padding:24px 24px 56px;  /* place pour le bouton */
+  transition:background 180ms ease;
+}
+.card:hover { background:linear-gradient(#1E1E26,#23232B); }
+```
+– Icône : carré 48 px, display:flex; align:center; justify:center;
+– Titre : 18 px, 700, couleur #FFFFFF, margin-top:12px;
+– Description : 14 px, #B7B7C0.
+– Badge catégorie : font-size:12px; background:#26262F; color:#B7B7C0; border-radius:4px; padding:2px 6px;
+
+Bouton “+” / “🗑️”
+```css
+.action-btn {
+  position:absolute; right:16px; bottom:16px;
+  width:44px; height:44px; border-radius:50%;
+  background:#15151B; border:1px solid #2A2A32;
+  display:flex; align-items:center; justify-content:center;
+  color:#C53A3A; transition:all 180ms ease;
+  box-shadow:0 2px 6px rgba(0,0,0,0.45);
+}
+.action-btn:hover {
+  background:radial-gradient(circle,#C53A3A 0%,#FF5858 100%);
+  color:#FFFFFF; transform:translateY(-2px) scale(1.05);
+}
+.action-btn:active { background:#FF5858; }
+```
+Animations globales
+transition:all 180ms ease-in-out; sur icônes, boutons et cartes.
+
+Accessibilité : contraste 4.5:1 min., outline:2px solid #FF5858 au focus clavier.
+
+— Fin du prompt —

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -9,7 +9,7 @@ La liste déroulante des applications se ferme désormais en appuyant hors du me
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
-Le Store utilise désormais un thème sombre rouge : fond #0d0d12 en dégradé, cartes 300×220 px et boutons « + » animés. Tout le texte emploie la police Montserrat.
+Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 280×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
 Lorsque l'on presse un autre bouton de cette barre, la liste d'applications se referme automatiquement.


### PR DESCRIPTION
## Résumé
- ajuste le style `store-dark.css` selon la nouvelle palette
- décrit le nouveau thème sombre dans la documentation
- ajoute le fichier `dark-mode-rouge.md` avec le détail des styles

## Tests
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_6844c99071bc832e9b72c540f7267847