### PR TITLE
Correctif Store + documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.15] - 2025-06-21 "StoreFix"
+
+### 🐛 Correctif
+- La page Store n'apparaît plus sur toutes les pages : un style CSS empêchait son masquage.
+
 ## [1.1.14] - 2025-06-20 "SidebarOffMobile"
 
 ### ✨ Interface mobile

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -8,9 +8,13 @@ body.theme-dark {
 #page-store {
     color: #ffffff;
     font-family: 'Montserrat', 'Inter', sans-serif;
-    display: flex;
+    display: none;
     flex-direction: column;
     padding: 40px 64px;
+}
+
+#page-store.active {
+    display: flex;
 }
 
 #page-store .store-controls {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -24,6 +24,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 280×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
+La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
 Lorsque l'on presse un autre bouton de cette barre, la liste d'applications se referme automatiquement.


### PR DESCRIPTION
## Summary
- clarifie dans la doc UI que la page Store est masquée tant qu'elle n'est pas active

## Testing
- `npm test` *(échoue : jest manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6846e42c599c832ea43b50a08988744d