### PR TITLE
Update store tile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Le Store adopte un mode sombre rouge : fond #0D0D12 avec dégradé radial #15151B, cartes 280×220 px et bouton d’action en bas à droite. La police Montserrat est utilisée pour cette section.
+- Les tuiles du Store affichent l'icône centrée au-dessus du texte, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -30,8 +30,8 @@ body.theme-dark {
 }
 
 #page-store .app-card {
-    width: 280px;
-    height: 220px;
+    width: 100%;
+    min-height: 220px;
     position: relative;
     background: #1a1a21;
     border: 1px solid #2a2a32;
@@ -40,6 +40,16 @@ body.theme-dark {
     transition: background 180ms ease;
     display: flex;
     flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+#page-store .separator {
+    width: 100%;
+    height: 2px;
+    margin: 8px 0;
+    background: linear-gradient(to right, #15151b, #2a2a32, #15151b);
+    border-radius: 2px;
 }
 
 #page-store .app-icon {
@@ -155,4 +165,10 @@ body.theme-dark {
 #page-store .search-icon .icon {
     color: #b7b7c0;
     transition: all 180ms ease-in-out;
+}
+
+@media (max-width: 768px) {
+    #page-store .app-card {
+        margin: 0 8px;
+    }
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -24,6 +24,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 280×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
+Les tuiles du Store affichent désormais l'icône au-dessus du texte, centrée et séparée par un dégradé gris. Sur mobile, elles s'étendent sur toute la largeur avec une légère marge.
 La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.

--- a/js/main.js
+++ b/js/main.js
@@ -242,12 +242,11 @@ function renderFilteredApps(apps) {
     
     appsGrid.innerHTML = apps.map(app => `
         <div class="app-card">
-            <div class="app-header">
-                <div class="app-icon">${app.icon}</div>
-                <div class="app-info">
-                    <h3>${app.name}</h3>
-                    <p>${app.description}</p>
-                </div>
+            <div class="app-icon">${app.icon}</div>
+            <div class="separator"></div>
+            <div class="app-info">
+                <h3>${app.name}</h3>
+                <p>${app.description}</p>
             </div>
             <div class="app-meta text-small text-muted">
                 <span>Catégorie: ${app.category}</span>

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -273,12 +273,11 @@ class UICore {
         
         appsGrid.innerHTML = apps.map(app => `
             <div class="app-card">
-                <div class="app-header">
-                    <div class="app-icon">${app.icon}</div>
-                    <div class="app-info">
-                        <h3>${app.name}</h3>
-                        <p>${app.description}</p>
-                    </div>
+                <div class="app-icon">${app.icon}</div>
+                <div class="separator"></div>
+                <div class="app-info">
+                    <h3>${app.name}</h3>
+                    <p>${app.description}</p>
                 </div>
                 <div class="app-meta text-small text-muted">
                     <span class="badge-category">${app.category}</span>


### PR DESCRIPTION
## Summary
- restructure store app cards to display the icon above the text
- add grey gradient separator for readability
- allow store tiles to take full width on mobile
- document the new behaviour in README and UI documentation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470962d044832e9b5a4639228e6382