### PR TITLE
Mise à jour design tuiles Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Le Store adopte un mode sombre rouge : fond #0D0D12 avec dégradé radial #15151B, cartes 280×220 px et bouton d’action en bas à droite. La police Montserrat est utilisée pour cette section.
-- Les tuiles du Store affichent l'icône centrée au-dessus du texte, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
+- Les tuiles du Store affichent l'icône centrée au-dessus du texte sur un léger fond rouge transparent, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.17] - 2025-06-23 "IconBG"
+
+### ✨ Interface Store
+- Icône des tuiles sur fond rouge très transparent pour un rendu minimaliste.
+
 ## [1.1.16] - 2025-06-22 "ChessAI"
 
 ### ✨ Application intégrée

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -58,6 +58,8 @@ body.theme-dark {
     display: flex;
     align-items: center;
     justify-content: center;
+    background-color: rgba(197, 58, 58, 0.1);
+    border-radius: 8px;
 }
 
 #page-store .app-card:hover {

--- a/docs/dark-mode-rouge.md
+++ b/docs/dark-mode-rouge.md
@@ -27,7 +27,7 @@ Carte application
 }
 .card:hover { background:linear-gradient(#1E1E26,#23232B); }
 ```
-– Icône : carré 48 px, display:flex; align:center; justify:center;
+– Icône : carré 48 px, display:flex; align:center; justify:center; fond rouge transparent (rgba(197,58,58,0.1)) avec coins arrondis.
 – Titre : 18 px, 700, couleur #FFFFFF, margin-top:12px;
 – Description : 14 px, #B7B7C0.
 – Badge catégorie : font-size:12px; background:#26262F; color:#B7B7C0; border-radius:4px; padding:2px 6px;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -24,7 +24,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 280×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
-Les tuiles du Store affichent désormais l'icône au-dessus du texte, centrée et séparée par un dégradé gris. Sur mobile, elles s'étendent sur toute la largeur avec une légère marge.
+Les tuiles du Store affichent désormais l'icône au-dessus du texte sur un fond rouge très transparent, centrée et séparée par un dégradé gris. Sur mobile, elles s'étendent sur toute la largeur avec une légère marge.
 La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.


### PR DESCRIPTION
## Notes
- Ajout d'un fond rouge très transparent sur la zone d'icône des tuiles du Store.
- Documentation mise à jour (README, docs).
- Journal des changements mis à jour.

## Tests
- `npm test` *(échoué : jest manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68471d1b7ff4832e870caab08fe24e10