### PR TITLE
Ajout d'un robot offline pour les échecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode PC, la barre latérale adopte un style de tuile plus sobre, sans barre de défilement.
 - En mode mobile, la barre latérale est désormais totalement masquée pour laisser la place à la navigation basse.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
+- Le jeu d'échecs intégré fonctionne même sans connexion : un robot joue aléatoirement lorsque l'API n'est pas renseignée.
 - La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
   1. **Installez des applications IA et services** — la tuile elle-même mène directement au Store et les applications installées apparaissent dans la barre de navigation.
   2. **Options du profil** — la tuile ouvre directement la page correspondante pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.

--- a/apps/chess/app.js
+++ b/apps/chess/app.js
@@ -78,7 +78,10 @@ function selectSquare(square) {
 }
 
 function aiMove() {
-    if (!aiEndpoint) return;
+    if (!aiEndpoint) {
+        localAiMove();
+        return;
+    }
     fetch(aiEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -89,9 +92,22 @@ function aiMove() {
             if (data && data.move) {
                 chess.move(data.move);
                 updateBoard();
+            } else {
+                localAiMove();
             }
         })
-        .catch(err => console.error('Erreur IA', err));
+        .catch(err => {
+            console.error('Erreur IA', err);
+            localAiMove();
+        });
+}
+
+function localAiMove() {
+    const moves = chess.moves();
+    if (moves.length === 0) return;
+    const move = moves[Math.floor(Math.random() * moves.length)];
+    chess.move(move);
+    updateBoard();
 }
 
 // Chargement initial

--- a/docs/app-readme.md
+++ b/docs/app-readme.md
@@ -7,4 +7,5 @@ Le module est utilisé par `UICore.toggleApp()` pour installer ou désinstaller 
 Depuis la version 1.1.0, chaque application possède un type (application, information, service ou formation) afin de faciliter le filtrage dans le Store.
 
 La formation **ChatGPT** fait partie des applications intégrées. Elle présente désormais un cours en dix pages avec quiz final pour apprendre à rédiger de bons prompts.
-Un jeu d'échecs connecté à une API IA fait aussi partie du catalogue.
+Un jeu d'échecs est également proposé. Il peut se connecter à une API IA,
+mais dispose désormais d'un robot intégré capable de jouer hors ligne.


### PR DESCRIPTION
## Notes
- Les tests Jest ne se lancent pas faute de dépendance installée.

## Summary
- ajout d'un robot hors ligne dans `apps/chess/app.js`
- mise à jour de la documentation des applications
- README enrichi avec la nouvelle fonctionnalité du jeu d'échecs


------
https://chatgpt.com/codex/tasks/task_e_68471d470524832eb60f4c30478071e0