### PR TITLE
Ajout menu IA pour les échecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode PC, la barre latérale adopte un style de tuile plus sobre, sans barre de défilement.
 - En mode mobile, la barre latérale est désormais totalement masquée pour laisser la place à la navigation basse.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
-- Le jeu d'échecs intégré fonctionne même sans connexion : un robot joue aléatoirement lorsque l'API n'est pas renseignée.
+- Le jeu d'échecs propose un menu pour choisir un moteur IA (Stockfish, LCZero…) et renseigner l'URL de l'API. Sans configuration, un robot local joue aléatoirement.
 - La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
   1. **Installez des applications IA et services** — la tuile elle-même mène directement au Store et les applications installées apparaissent dans la barre de navigation.
   2. **Options du profil** — la tuile ouvre directement la page correspondante pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.

--- a/apps/chess/app.html
+++ b/apps/chess/app.html
@@ -1,6 +1,13 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
 <div class="chess-app">
     <div class="chess-config">
+        <label for="ai-select">Moteur IA :</label>
+        <select id="ai-select" onchange="updateAiEngine()">
+            <option value="">Robot local</option>
+            <option value="lichess">Stockfish (Lichess)</option>
+            <option value="stockfish">Stockfish (Exemple)</option>
+            <option value="lc0">LCZero</option>
+        </select>
         <label for="ai-endpoint">URL de l'API IA :</label>
         <input type="text" id="ai-endpoint" placeholder="https://exemple.com/api/chess" />
         <button onclick="saveAiEndpoint()">Enregistrer</button>

--- a/apps/chess/app.js
+++ b/apps/chess/app.js
@@ -2,11 +2,24 @@
 let chess = null;
 let selectedSquare = null;
 let aiEndpoint = '';
+const aiEndpoints = {
+    '': '',
+    'lichess': 'https://lichess.org/api/cloud-eval',
+    'stockfish': 'https://example.com/api/stockfish',
+    'lc0': 'https://example.com/api/lc0'
+};
 
 function initChess() {
-    const saved = localStorage.getItem('c2r_chess_ai');
-    if (saved) {
-        aiEndpoint = saved;
+    const savedEngine = localStorage.getItem('c2r_chess_engine');
+    const savedEndpoint = localStorage.getItem('c2r_chess_ai');
+    if (savedEngine) {
+        document.getElementById('ai-select').value = savedEngine;
+    }
+    if (savedEndpoint) {
+        aiEndpoint = savedEndpoint;
+        document.getElementById('ai-endpoint').value = aiEndpoint;
+    } else if (savedEngine) {
+        aiEndpoint = aiEndpoints[savedEngine] || '';
         document.getElementById('ai-endpoint').value = aiEndpoint;
     }
     chess = new Chess();
@@ -16,6 +29,14 @@ function initChess() {
 
 function saveAiEndpoint() {
     aiEndpoint = document.getElementById('ai-endpoint').value;
+    localStorage.setItem('c2r_chess_ai', aiEndpoint);
+}
+
+function updateAiEngine() {
+    const engine = document.getElementById('ai-select').value;
+    localStorage.setItem('c2r_chess_engine', engine);
+    aiEndpoint = aiEndpoints[engine] || '';
+    document.getElementById('ai-endpoint').value = aiEndpoint;
     localStorage.setItem('c2r_chess_ai', aiEndpoint);
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.18] - 2025-06-24 "ChessEngineSelect"
+
+### ✨ Application Échecs
+- Ajout d'un menu déroulant pour choisir un moteur IA (Stockfish, LCZero…).
+- L'URL de l'API se remplit automatiquement et peut être modifiée manuellement.
+- Sans API choisie, un robot local joue les coups.
+
 ## [1.1.17] - 2025-06-23 "StoreTilesMobile"
 
 ### 📅 Interface mobile

--- a/docs/app-readme.md
+++ b/docs/app-readme.md
@@ -7,5 +7,7 @@ Le module est utilisé par `UICore.toggleApp()` pour installer ou désinstaller 
 Depuis la version 1.1.0, chaque application possède un type (application, information, service ou formation) afin de faciliter le filtrage dans le Store.
 
 La formation **ChatGPT** fait partie des applications intégrées. Elle présente désormais un cours en dix pages avec quiz final pour apprendre à rédiger de bons prompts.
-Un jeu d'échecs est également proposé. Il peut se connecter à une API IA,
-mais dispose désormais d'un robot intégré capable de jouer hors ligne.
+Un jeu d'échecs est également proposé. Il peut se connecter à une API IA grâce
+à un menu déroulant listant plusieurs moteurs (Stockfish, LCZero…). Le champ
+situé dessous permet de saisir l'URL de l'API. Sans configuration, un robot
+local joue hors ligne.


### PR DESCRIPTION
## Notes
- Les tests Jest ne se lancent pas dans l'environnement (`jest: not found`).

## Résumé
- ajout d'un menu déroulant de moteurs IA dans l'appli Échecs
- remplissage automatique de l'URL d'API avec possibilité de modification
- documentation et changelog mis à jour

------
https://chatgpt.com/codex/tasks/task_e_68472f52fc48832eb973c1d23bfae0ff