### PR TITLE
Ajout tuile accès échecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode mobile, la barre latérale est désormais totalement masquée pour laisser la place à la navigation basse.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - Le jeu d'échecs propose un menu pour choisir un moteur IA (Stockfish, LCZero…) et renseigner l'URL de l'API. Sans configuration, un robot local joue aléatoirement.
+- Une page autonome `chess.html` affiche directement l'échiquier prêt à jouer dès l'ouverture.
+- Une tuile "Jouer aux échecs" sur la page d'accueil ouvre cette page autonome dans un nouvel onglet.
 - La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
   1. **Installez des applications IA et services** — la tuile elle-même mène directement au Store et les applications installées apparaissent dans la barre de navigation.
   2. **Options du profil** — la tuile ouvre directement la page correspondante pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.

--- a/chess.html
+++ b/chess.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jeu d'échecs</title>
+    <link rel="stylesheet" href="apps/chess/app.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
+    <script src="apps/chess/app.js" defer></script>
+</head>
+<body>
+    <div class="chess-app">
+        <div class="chess-config">
+            <label for="ai-select">Moteur IA :</label>
+            <select id="ai-select" onchange="updateAiEngine()">
+                <option value="">Robot local</option>
+                <option value="lichess">Stockfish (Lichess)</option>
+                <option value="stockfish">Stockfish (Exemple)</option>
+                <option value="lc0">LCZero</option>
+            </select>
+            <label for="ai-endpoint">URL de l'API IA :</label>
+            <input type="text" id="ai-endpoint" placeholder="https://exemple.com/api/chess" />
+            <button onclick="saveAiEndpoint()">Enregistrer</button>
+        </div>
+        <div id="chess-status" class="chess-status">Votre coup</div>
+        <table id="chess-board" class="chess-board"></table>
+    </div>
+</body>
+</html>

--- a/docs/chess-readme.md
+++ b/docs/chess-readme.md
@@ -1,0 +1,7 @@
+# Application d'échecs autonome
+
+Cette page permet de jouer immédiatement aux échecs. Les pièces sont en place dès l'ouverture et chaque déplacement est géré par la bibliothèque **chess.js**.
+
+Ouvrez simplement `chess.html` pour démarrer une partie contre un adversaire humain ou un petit robot local. Un menu permet également de renseigner l'URL d'un moteur IA compatible.
+
+Vous pouvez aussi cliquer sur la tuile « Jouer aux échecs » depuis la page d'accueil pour ouvrir ce même échiquier dans un nouvel onglet.

--- a/index.html
+++ b/index.html
@@ -113,6 +113,11 @@
                             <h3>Installez des applications IA et services</h3>
                             <p>Explorez le Store pour trouver des intelligences artificielles, des formations ou des services. Les applications installées apparaissent ensuite dans la barre de navigation.</p>
                         </a>
+                        <a href="chess.html" target="_blank" class="card info-tile">
+                            <span data-icon="chess"></span>
+                            <h3>Jouer aux échecs</h3>
+                            <p>Ouvre l'échiquier complet dans un nouvel onglet.</p>
+                        </a>
                         <a href="#profile" data-page="profile" class="card info-tile">
                             <span data-icon="profile"></span>
                             <h3>Options du profil</h3>


### PR DESCRIPTION
## Notes
- Les tests npm échouent car `jest` est manquant dans l'environnement.

## Summary
- nouveau lien "Jouer aux échecs" sur la page d'accueil
- README mis à jour avec l'accès direct
- documentation de l'échiquier complétée

## Testing
- ❌ `npm test` (jest non trouvé)

------
https://chatgpt.com/codex/tasks/task_e_68473578966c832eac3804c99d9cbc02