### PR TITLE
Correction de la grille du Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Les icônes de la liste déroulante des applications sont désormais d'un gris neutre pour un rendu minimaliste.
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Le Store adopte un mode sombre rouge : fond #0D0D12 avec dégradé radial #15151B, cartes 280×220 px et bouton d’action en bas à droite. La police Montserrat est utilisée pour cette section.
-- Les tuiles du Store affichent l'icône centrée au-dessus du texte, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
-- Les tuiles du Store s'ajustent desormais automatiquement a la largeur des smartphones.
+ - Les tuiles du Store affichent l'icône centrée au-dessus du texte, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
+ - La grille du Store affiche deux colonnes dès 600 px et revient à une seule colonne sur mobile.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/css/layout.css
+++ b/css/layout.css
@@ -299,7 +299,7 @@ body.sidebar-right .sidebar {
 
 .apps-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: var(--c2r-spacing-lg);
     margin-top: var(--c2r-spacing-xl);
 }

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -25,7 +25,7 @@ body.theme-dark {
 
 #page-store .apps-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 32px;
 }
 
@@ -169,10 +169,16 @@ body.theme-dark {
 
 @media (max-width: 768px) {
     #page-store .apps-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     }
 
     #page-store .app-card {
         margin: 0 8px;
+    }
+}
+
+@media (max-width: 600px) {
+    #page-store .apps-grid {
+        grid-template-columns: 1fr;
     }
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -24,7 +24,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 280×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
-Les tuiles du Store affichent désormais l'icône au-dessus du texte, centrée et séparée par un dégradé gris. Sur mobile, elles s'étendent sur toute la largeur avec une légère marge.
+Les tuiles du Store affichent désormais l'icône au-dessus du texte, centrée et séparée par un dégradé gris. Sur mobile, elles s'étendent sur toute la largeur avec une légère marge. La grille affiche deux colonnes dès 600 px de large et une seule colonne sur mobile.
 La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.


### PR DESCRIPTION
## Summary
- régler l'affichage du Store pour qu'il passe à deux colonnes dès 600 px
- conserver une seule colonne sur mobile
- documenter ce nouveau comportement

## Testing
- `npm test` *(échoue : jest non installé)*

------
https://chatgpt.com/codex/tasks/task_e_68472e973c74832ebb9e4885733916a0