### PR TITLE
Amélioration du plateau d'échecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode mobile, la barre latérale est désormais totalement masquée pour laisser la place à la navigation basse.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - Le jeu d'échecs propose un menu pour choisir un moteur IA (Stockfish, LCZero…) et renseigner l'URL de l'API. Sans configuration, un robot local joue aléatoirement.
+- Une page autonome `chess.html` affiche directement l'échiquier prêt à jouer dès l'ouverture.
+- Une tuile "Jouer aux échecs" sur la page d'accueil ouvre cette page autonome dans un nouvel onglet.
 - La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
   1. **Installez des applications IA et services** — la tuile elle-même mène directement au Store et les applications installées apparaissent dans la barre de navigation.
   2. **Options du profil** — la tuile ouvre directement la page correspondante pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.
@@ -70,3 +72,10 @@ Vous pouvez ensuite exécuter les tests avec :
 ```bash
 npm test
 ```
+
+## Jeu d'échecs
+
+Deux méthodes pour jouer immédiatement :
+1. Lancez un petit serveur local (`python3 -m http.server 8000`) puis ouvrez `chess.html`.
+2. Depuis `index.html`, cliquez sur la tuile « Jouer aux échecs » pour ouvrir le plateau dans un nouvel onglet.
+Les pièces apparaissent déjà en place et il suffit de sélectionner une case pour déplacer vos blancs.

--- a/apps/chess/app.css
+++ b/apps/chess/app.css
@@ -1,21 +1,26 @@
 .chess-board {
     border-collapse: collapse;
+    border: 2px solid #333;
     margin-top: 10px;
 }
 .chess-board td {
-    width: 40px;
-    height: 40px;
+    width: 60px;
+    height: 60px;
     text-align: center;
     vertical-align: middle;
-    font-size: 24px;
+    font-size: 32px;
     cursor: pointer;
+    border: 1px solid #333;
 }
 .chess-board .white {
-    background-color: #eee;
+    background-color: #f0d9b5;
 }
 .chess-board .black {
-    background-color: #666;
+    background-color: #b58863;
     color: #fff;
+}
+.chess-board td.selected {
+    outline: 3px solid #ff0000;
 }
 .chess-status {
     margin-top: 10px;

--- a/apps/chess/app.js
+++ b/apps/chess/app.js
@@ -64,6 +64,7 @@ function updateBoard() {
         const square = cell.dataset.square;
         const piece = chess.get(square);
         cell.textContent = piece ? pieceToChar(piece) : '';
+        cell.classList.remove('selected');
     }
     document.getElementById('chess-status').textContent = chess.turn() === 'w' ? 'Votre coup' : 'Coup de l\'IA';
 }
@@ -78,23 +79,29 @@ function pieceToChar(piece) {
 
 function selectSquare(square) {
     if (chess.turn() === 'b') return; // attendre IA
+    const board = document.getElementById('chess-board');
     if (selectedSquare) {
-        const move = { from: selectedSquare, to: square };
-        const result = chess.move(move);
-        if (result) {
-            selectedSquare = null;
-            updateBoard();
-            if (!chess.game_over()) {
-                aiMove();
+        const prev = board.querySelector(`[data-square="${selectedSquare}"]`);
+        if (prev) prev.classList.remove('selected');
+        if (selectedSquare !== square) {
+            const move = { from: selectedSquare, to: square };
+            const result = chess.move(move);
+            if (result) {
+                selectedSquare = null;
+                updateBoard();
+                if (!chess.game_over()) {
+                    aiMove();
+                }
+                return;
             }
-        } else {
-            selectedSquare = null;
         }
-    } else {
-        const piece = chess.get(square);
-        if (piece && piece.color === 'w') {
-            selectedSquare = square;
-        }
+        selectedSquare = null;
+    }
+    const piece = chess.get(square);
+    if (piece && piece.color === 'w') {
+        selectedSquare = square;
+        const cell = board.querySelector(`[data-square="${square}"]`);
+        if (cell) cell.classList.add('selected');
     }
 }
 
@@ -132,4 +139,4 @@ function localAiMove() {
 }
 
 // Chargement initial
-initChess();
+document.addEventListener('DOMContentLoaded', initChess);

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,16 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.20] - 2025-06-26 "ChessDesign"
+
+### ✨ Échiquier amélioré
+- Les cases sont plus grandes et la sélection est mise en évidence.
+- L'IA joue automatiquement après votre coup.
+
+## [1.1.19] - 2025-06-25 "ChessQuickPage"
+
+### ✨ Accès direct au jeu d'échecs
+- Ajout de la page `chess.html` prête à jouer.
+- Une tuile "Jouer aux échecs" ouvre cette page depuis l'accueil.
+
 
 ## [1.1.18] - 2025-06-24 "ChessEngineSelect"
 

--- a/chess.html
+++ b/chess.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jeu d'échecs</title>
+    <link rel="stylesheet" href="apps/chess/app.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
+    <script src="apps/chess/app.js" defer></script>
+</head>
+<body>
+    <h1>Échiquier</h1>
+    <div class="chess-app">
+        <div class="chess-config">
+            <label for="ai-select">Moteur IA :</label>
+            <select id="ai-select" onchange="updateAiEngine()">
+                <option value="">Robot local</option>
+                <option value="lichess">Stockfish (Lichess)</option>
+                <option value="stockfish">Stockfish (Exemple)</option>
+                <option value="lc0">LCZero</option>
+            </select>
+            <label for="ai-endpoint">URL de l'API IA :</label>
+            <input type="text" id="ai-endpoint" placeholder="https://exemple.com/api/chess" />
+            <button onclick="saveAiEndpoint()">Enregistrer</button>
+        </div>
+        <div id="chess-status" class="chess-status">Votre coup</div>
+        <table id="chess-board" class="chess-board"></table>
+    </div>
+</body>
+</html>

--- a/docs/app-readme.md
+++ b/docs/app-readme.md
@@ -11,3 +11,4 @@ Un jeu d'échecs est également proposé. Il peut se connecter à une API IA gr�
 à un menu déroulant listant plusieurs moteurs (Stockfish, LCZero…). Le champ
 situé dessous permet de saisir l'URL de l'API. Sans configuration, un robot
 local joue hors ligne.
+Une page `chess.html` permet de jouer instantanément, accessible aussi via la tuile "Jouer aux échecs" sur la page d'accueil. L'échiquier s'affiche dès l'ouverture avec un design amélioré.

--- a/docs/chess-readme.md
+++ b/docs/chess-readme.md
@@ -1,0 +1,8 @@
+# Application d'échecs autonome
+
+Cette page permet de jouer immédiatement aux échecs. Les pièces sont en place dès l'ouverture et chaque déplacement est géré par la bibliothèque **chess.js**.
+
+Ouvrez simplement `chess.html` pour démarrer une partie contre un adversaire humain ou un petit robot local. Un menu permet de renseigner l'URL d'un moteur IA compatible.
+
+Vous pouvez aussi cliquer sur la tuile « Jouer aux échecs » depuis la page d'accueil pour ouvrir ce même échiquier dans un nouvel onglet.
+Les pièces se déplacent comme sur un échiquier réel. La case sélectionnée est surlignée en rouge et l'IA joue à son tour si vous avez renseigné son URL.

--- a/index.html
+++ b/index.html
@@ -113,6 +113,11 @@
                             <h3>Installez des applications IA et services</h3>
                             <p>Explorez le Store pour trouver des intelligences artificielles, des formations ou des services. Les applications installées apparaissent ensuite dans la barre de navigation.</p>
                         </a>
+                        <a href="chess.html" target="_blank" class="card info-tile">
+                            <span data-icon="chess"></span>
+                            <h3>Jouer aux échecs</h3>
+                            <p>Ouvre l'échiquier complet dans un nouvel onglet.</p>
+                        </a>
                         <a href="#profile" data-page="profile" class="card info-tile">
                             <span data-icon="profile"></span>
                             <h3>Options du profil</h3>


### PR DESCRIPTION
## Notes
- Les tests npm échouent car `jest` est manquant dans l'environnement.

## Summary
- style du plateau revu pour des cases plus grandes et un surlignage rouge
- code JavaScript mis à jour pour gérer la sélection et lancer l'IA après chaque coup
- documentation enrichie avec des explications détaillées pour lancer `chess.html`
- changement de version dans `changelog.md`

## Testing
- ❌ `npm test` (jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68473578966c832eac3804c99d9cbc02