### PR TITLE
Ajustement du Store en mode paysage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 xf4rjg-codex/2025-06-12
  - Le Store adopte un mode sombre rouge : fond #0D0D12 avec dégradé radial #15151B, cartes 220×220 px et bouton d’action en bas à droite. La police Montserrat est utilisée pour cette section.
-  - Les tuiles du Store affichent l'icône centrée au-dessus du texte, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
-  - La grille du Store ajuste ses colonnes automatiquement (auto-fit minmax 220px) et passe à deux colonnes dès 600 px avant de revenir à une seule sur mobile.
+- Les tuiles du Store affichent l'icône centrée au-dessus du texte, séparée par un dégradé gris. En mode mobile, elles prennent toute la largeur avec une petite marge.
+- La grille du Store ajuste ses colonnes automatiquement (auto-fit minmax 220px) et passe à deux colonnes dès 600 px avant de revenir à une seule sur mobile.
+- Les tuiles passent en orientation paysage avec une zone supérieure rouge translucide contenant l'icône.
 =======
 - Le Store adopte un mode sombre rouge : fond #0D0D12 avec dégradé radial #15151B, cartes 280×220 px et bouton d’action en bas à droite. La police Montserrat est utilisée pour cette section.
 fgyfdn-codex/2025-06-09

--- a/css/layout.css
+++ b/css/layout.css
@@ -311,8 +311,25 @@ body.sidebar-right .sidebar {
     padding: var(--c2r-spacing-lg);
     transition: var(--c2r-transition);
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: var(--c2r-spacing-md);
+    text-align: left;
+}
+
+.app-top {
+    width: 100%;
+    padding: var(--c2r-spacing-sm) var(--c2r-spacing-md);
+    background-color: rgba(197, 58, 58, 0.15);
+    color: var(--c2r-text-muted);
+    border-radius: var(--c2r-radius) var(--c2r-radius) 0 0;
+}
+
+.app-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    justify-content: center;
+    gap: var(--c2r-spacing-sm);
 }
 
 .app-card:hover {

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -35,17 +35,34 @@ main
 
 #page-store .app-card {
     width: 100%;
-    min-height: 220px;
+    min-height: 160px;
     position: relative;
     background: #1a1a21;
     border: 1px solid #2a2a32;
     border-radius: 16px;
-    padding: 24px 24px 56px;
+    padding: 16px 24px;
     transition: background 180ms ease;
     display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    text-align: left;
+}
+
+#page-store .app-top {
+    width: 100%;
+    padding: 4px 8px;
+    background-color: rgba(197, 58, 58, 0.15);
+    color: rgba(255, 255, 255, 0.8);
+    border-radius: 12px 12px 0 0;
+}
+
+#page-store .app-content {
+    display: flex;
     flex-direction: column;
-    align-items: center;
-    text-align: center;
+    flex: 1;
+    padding-left: 16px;
+    gap: 8px;
+    justify-content: center;
 }
 
 #page-store .separator {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -26,6 +26,7 @@ La barre de recherche du Store se masque automatiquement lors du défilement ver
 xf4rjg-codex/2025-06-12
 Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 220×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
 Les tuiles du Store affichent l'icône au-dessus du texte, centrée et séparée par un dégradé gris. Sur mobile, elles s'étendent sur toute la largeur avec une légère marge. La grille ajuste automatiquement ses colonnes (auto-fit minmax 220px) : deux colonnes dès 600 px de large puis une seule en dessous.
+Depuis la dernière mise à jour, elles sont présentées en orientation paysage avec une bande supérieure rouge translucide accueillant l'icône.
 =======
 Le Store utilise désormais un thème sombre rouge : fond #0D0D12 avec un dégradé radial #15151B, cartes 280×220 px et bouton d’action positionné en bas à droite. Tout le texte emploie la police Montserrat.
 fgyfdn-codex/2025-06-09

--- a/js/main.js
+++ b/js/main.js
@@ -242,21 +242,24 @@ function renderFilteredApps(apps) {
     
     appsGrid.innerHTML = apps.map(app => `
         <div class="app-card">
-            <div class="app-icon">${app.icon}</div>
-            <div class="separator"></div>
-            <div class="app-info">
-                <h3>${app.name}</h3>
-                <p>${app.description}</p>
+            <div class="app-top">
+                <div class="app-icon">${app.icon}</div>
             </div>
-            <div class="app-meta text-small text-muted">
-                <span>Catégorie: ${app.category}</span>
-                <span>Type: ${app.type || 'application'}</span>
-                <span>Version: ${app.version}</span>
-                <span>Taille: ${app.size}</span>
-                <span>Auteur: ${app.author}</span>
-            </div>
-            <div class="app-permissions text-small">
-                <strong>Permissions:</strong> ${app.permissions.join(', ') || 'Aucune'}
+            <div class="app-content">
+                <div class="app-info">
+                    <h3>${app.name}</h3>
+                    <p>${app.description}</p>
+                </div>
+                <div class="app-meta text-small text-muted">
+                    <span>Catégorie: ${app.category}</span>
+                    <span>Type: ${app.type || 'application'}</span>
+                    <span>Version: ${app.version}</span>
+                    <span>Taille: ${app.size}</span>
+                    <span>Auteur: ${app.author}</span>
+                </div>
+                <div class="app-permissions text-small">
+                    <strong>Permissions:</strong> ${app.permissions.join(', ') || 'Aucune'}
+                </div>
             </div>
             <div class="app-actions">
                 <button class="app-toggle-btn ${appCore.isInstalled(app.id) ? 'installed' : ''}"

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -273,16 +273,19 @@ class UICore {
         
         appsGrid.innerHTML = apps.map(app => `
             <div class="app-card">
-                <div class="app-icon">${app.icon}</div>
-                <div class="separator"></div>
-                <div class="app-info">
-                    <h3>${app.name}</h3>
-                    <p>${app.description}</p>
+                <div class="app-top">
+                    <div class="app-icon">${app.icon}</div>
                 </div>
-                <div class="app-meta text-small text-muted">
-                    <span class="badge-category">${app.category}</span>
-                    <span>Date: ${app.version}</span>
-                    <span>Taille: ${app.size}</span>
+                <div class="app-content">
+                    <div class="app-info">
+                        <h3>${app.name}</h3>
+                        <p>${app.description}</p>
+                    </div>
+                    <div class="app-meta text-small text-muted">
+                        <span class="badge-category">${app.category}</span>
+                        <span>Date: ${app.version}</span>
+                        <span>Taille: ${app.size}</span>
+                    </div>
                 </div>
                 <div class="app-actions">
                     <button class="app-toggle-btn ${appCore.isInstalled(app.id) ? 'installed' : ''}"


### PR DESCRIPTION
## Summary
- orientation paysage pour `.app-card`
- zone supérieure rouge translucide
- génération HTML ajustée
- mise à jour de la documentation

## Testing
- `npm test` *(échoue : jest indisponible)*

------
https://chatgpt.com/codex/tasks/task_e_6850900deaec832e8b7625a4ee56fdc0