### PR TITLE
Nettoyage du conteneur app-runner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
 
 ### ♻️ Tuiles du Store uniformisées
 - La grille du Store reprend le format des cartes d'accueil pour un rendu cohérent.
+## [1.1.23] - 2025-07-02 "RemoveRunner"
+
+### 🔧 Nettoyage
+- Suppression du composant obsolète `app-runner` et du CSS associé.
 ## [1.1.21] - 2025-06-30 "NoSidebarToggle"
 
 ### 🔧 Suppression du mode compact

--- a/css/global.css
+++ b/css/global.css
@@ -554,46 +554,6 @@ tr:last-child td {
     font-weight: var(--font-weight-medium);
 }
 
-/* Zone d'exécution des applications */
-.app-runner {
-    position: fixed;
-    top: 10%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 80%;
-    max-width: 800px;
-    height: 70%;
-    background-color: var(--c2r-bg-card);
-    border: 1px solid var(--c2r-border);
-    border-radius: var(--c2r-radius);
-    box-shadow: var(--c2r-shadow-lg);
-    z-index: 500;
-    display: flex;
-    flex-direction: column;
-}
-
-.app-header {
-    padding: var(--c2r-spacing-md);
-    border-bottom: 1px solid var(--c2r-border-light);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background-color: var(--c2r-bg-secondary);
-    border-radius: var(--c2r-radius) var(--c2r-radius) 0 0;
-}
-
-.app-header h3 {
-    margin: 0;
-    color: var(--c2r-text);
-    font-size: var(--font-size-md);
-}
-
-.app-content {
-    flex: 1;
-    padding: var(--c2r-spacing-lg);
-    overflow: auto;
-    background-color: var(--c2r-bg);
-}
 
 /* Notifications */
 .notifications-container {
@@ -652,13 +612,6 @@ body[data-info-popups='disabled'] .notifications-container {
         display: none;
     }
     
-    .app-runner {
-        top: 5%;
-        left: 5%;
-        transform: none;
-        width: 90%;
-        height: 85%;
-    }
     
     .modal-content {
         margin: 20px;

--- a/docs/app-readme.md
+++ b/docs/app-readme.md
@@ -13,3 +13,5 @@ situé dessous permet de saisir l'URL de l'API. Sans configuration, un robot
 local joue hors ligne.
 Une page `chess.html` permet de jouer instantanément, accessible aussi via la tuile "Jouer aux échecs" sur la page d'accueil. L'échiquier s'affiche dès l'ouverture avec un design amélioré.
 Une nouvelle application **Notes Vocales** enregistre la voix de l'utilisateur puis utilise Whisper pour la convertir automatiquement en texte.
+
+Depuis juillet 2025, les applications s'ouvrent dans des modales générées par `UICore`. Le conteneur obsolète `.app-runner` a été supprimé pour éviter l'apparition d'une tuile « Application » inutile.

--- a/index.html
+++ b/index.html
@@ -425,16 +425,6 @@
         </div>
     </div>
 
-    <!-- Zone d'exécution des applications -->
-    <div class="app-runner" id="app-runner" style="display: none;">
-        <div class="app-header">
-            <h3 id="running-app-title">Application</h3>
-            <button class="btn btn-small btn-secondary" id="close-app">Fermer</button>
-        </div>
-        <div class="app-content" id="app-content">
-            <!-- Contenu de l'application en cours -->
-        </div>
-    </div>
 
     <!-- Chargement des modules C2R OS dans l'ordre de dépendance -->
     <script src="js/modules/core/config.js"></script>


### PR DESCRIPTION
## Résumé
- suppression du bloc `app-runner` dans `index.html`
- retrait des styles associés dans `global.css`
- mise à jour de `docs/app-readme.md` pour préciser l'usage des modales
- ajout d'une entrée au `changelog`

## Tests
- `npm test` *(échec : jest manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68533d6dcae4832ea8cc571762653f6e