### PR TITLE
Ajout couleur survol icônes apps

### DIFF
--- a/css/apps.css
+++ b/css/apps.css
@@ -37,6 +37,10 @@
     color: var(--c2r-text);
 }
 
+.sidebar-app-item:hover .app-icon {
+    color: #ff5858;
+}
+
 .sidebar-app-item .app-icon {
     font-size: var(--font-size-md);
     min-width: 20px;

--- a/css/icons.css
+++ b/css/icons.css
@@ -128,6 +128,10 @@
     color: var(--text-secondary);
 }
 
+.sidebar-app-item:hover .icon {
+    color: #ff5858;
+}
+
 .minimal-sidebar .sidebar-app-item .icon {
     font-size: 1.2rem;
     margin-right: 0;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -52,7 +52,7 @@ La barre latérale bénéficie d'un fond dégradé gris et d'une ombre pour s'in
 
 En affichage **PC**, la sidebar adopte désormais un style de tuile plus sobre sans barre de défilement verticale.
 
-Les textes des éléments disparaissent pour ne laisser que les icônes. Au passage de la souris, celles-ci se colorent en rouge et une info‑bulle identique apparaît pour chaque icône, qu'elle provienne du menu principal ou des applications.
+Les textes des éléments disparaissent pour ne laisser que les icônes. Au passage de la souris, celles-ci se colorent en rouge et une info‑bulle identique apparaît pour chaque icône, qu'elle provienne du menu principal ou des applications. La règle `.sidebar-app-item:hover .app-icon` applique désormais explicitement la couleur `#ff5858` aux icônes des applications.
 
 ## Nouvelle barre latérale C2R
 La version sombre fixe adopte une largeur de 72 px. Son fond est un dégradé vertical (#0d0d12→#15151b) et la bordure droite utilise #2a2a32. Les icônes centrées changent de couleur au survol (#ff5858). Le logo "C2R" en haut mesure 26 px et la police Montserrat est utilisée pour tout le contenu.


### PR DESCRIPTION
## Notes
- Les tests npm échouent car `jest` n'est pas disponible dans l'environnement.

## Summary
- mise à jour du style pour surligner les icônes d'applications en rouge (#ff5858)
- même comportement appliqué dans `icons.css`
- documentation `ui-readme.md` mise à jour pour signaler la nouvelle règle CSS


------
https://chatgpt.com/codex/tasks/task_e_685343647170832ebabb919148de6603