### PR TITLE
Ajuste affichage mobile store

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
 
-- Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge.
+- Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge, placée en bas à droite des tuiles sans fond circulaire.
 - Les icônes d'installation sont alignées à droite des tuiles pour plus de clarté.
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
 - En mode mobile, la poubelle s'affiche désormais en rouge grâce à une règle CSS dédiée.

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -122,21 +122,20 @@ body.theme-dark {
 #page-store .app-actions {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
     margin-top: auto;
+    width: 100%;
 }
 
 #page-store .app-toggle-btn {
-    width: 44px;
-    height: 44px;
-    border-radius: 50%;
-    border: 1px solid #2a2a32;
-    background: #15151b;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+    border: none;
+    background: none;
+    box-shadow: none;
+    color: #c53a3a;
+    padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #c53a3a;
     transition: all 180ms ease-in-out;
 }
 
@@ -147,7 +146,6 @@ body.theme-dark {
 }
 
 #page-store .app-toggle-btn:hover {
-    background: radial-gradient(circle at center, #c53a3a, #ff5858);
     transform: translateY(-2px) scale(1.05);
 }
 
@@ -156,12 +154,11 @@ body.theme-dark {
 }
 
 #page-store .app-toggle-btn:active {
-    background: #ff5858;
-    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.55);
+    box-shadow: none;
 }
 
 #page-store .app-toggle-btn:focus {
-    outline: 2px solid #ff5858;
+    outline: none;
 }
 
 #page-store .app-toggle-btn:active .icon {
@@ -192,7 +189,7 @@ body.theme-dark {
     }
 
     #page-store .app-card {
-        margin: 0 8px;
+        margin: 0;
     }
 }
 

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -16,7 +16,7 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 | Gris clair (texte secondaire) | `#B7B7C0` |
 | Gris placeholder (inputs) | `#5E5E66` |
 
-Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
+Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée en bas à droite de chaque tuile. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
 Lorsqu'un utilisateur tente d'installer une application sans être connecté, une notification indique désormais « Veuillez vous connecter pour installer ».
 Un bref retour tactile confirme aussi l'installation ou la désinstallation sur les appareils compatibles.
 La liste déroulante des applications se ferme désormais en appuyant hors du menu ; la petite croix a été supprimée.
@@ -25,7 +25,7 @@ Le titre "Applications installées" a été retiré pour gagner de la place et l
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store adopte un thème sombre rouge (fond `#0D0D12` avec dégradé `#15151B`).
 Les tuiles reprennent le format des cartes d'accueil : icône au-dessus du texte, disposition verticale et grille responsive (auto-fit `minmax(240px, 1fr)`).
-Sur mobile, chaque tuile s'étend sur la largeur disponible avec une petite marge.
+Sur mobile, chaque tuile occupe désormais toute la largeur de l'écran.
 La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.


### PR DESCRIPTION
## Notes
- `npm test` a échoué car `jest` est manquant dans l'environnement.

## Summary
- aligne le bouton d'installation à droite et retire le fond circulaire
- largeur 100 % des tuiles en affichage mobile
- documentation mise à jour sur ces changements

## Testing
- `npm test` *(échoue : jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534a00b568832e87917ccbd2a85af0