### PR TITLE
Suppression de la ligne de séparation du header

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.25] - 2025-07-04 "NoHeaderLine"
+
+### ✨ En-tête épuré
+- Suppression de la bordure inférieure de la barre latérale pour retirer la séparation au-dessus de l'icône Accueil.
+
 ## [1.1.24] - 2025-07-03 "SidebarFlat"
 
 ### 🎨 Barre latérale simplifiée

--- a/css/layout.css
+++ b/css/layout.css
@@ -34,7 +34,7 @@ body.sidebar-right .sidebar {
 
 .sidebar-header {
     padding: var(--c2r-spacing-lg);
-    border-bottom: 1px solid var(--c2r-border);
+    /* Suppression de la ligne de séparation sous l'en-tête */
     display: flex;
     align-items: center;
     justify-content: space-between;


### PR DESCRIPTION
## Notes
- Ajout d'une entrée de changelog détaillant la suppression de la bordure sous l'en‑tête de la barre latérale.
- Mise à jour de `css/layout.css` pour retirer cette bordure.

## Tests
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_68535274fc5c832ea98aa0fc507583fa