### PR TITLE
Mise à jour du bouton du Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
 
-- Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge, placée en bas à droite des tuiles sans fond circulaire.
-- Les icônes d'installation sont alignées à droite des tuiles pour plus de clarté.
+- Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge, positionnée sur la droite de chaque tuile sans aucun arrière-plan.
+- Les icônes d'installation sont centrées sur la droite des tuiles pour plus de clarté et ne possèdent aucun fond.
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
 - En mode mobile, la poubelle s'affiche désormais en rouge grâce à une règle CSS dédiée.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.25] - 2025-07-04 "StoreButton"
+
+### 🎨 Bouton du Store
+- Le bouton d'installation ne possède plus d'arrière-plan et se situe à présent sur la droite de chaque tuile.
+
 ## [1.1.24] - 2025-07-03 "SidebarFlat"
 
 ### 🎨 Barre latérale simplifiée

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -122,14 +122,19 @@ body.theme-dark {
 #page-store .app-actions {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    margin-top: auto;
-    width: 100%;
+    justify-content: center;
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+    margin-top: 0;
+    width: auto;
 }
 
 #page-store .app-toggle-btn {
     border: none;
     background: none;
+    background-color: transparent;
     box-shadow: none;
     color: #c53a3a;
     padding: 0;
@@ -147,6 +152,7 @@ body.theme-dark {
 
 #page-store .app-toggle-btn:hover {
     transform: translateY(-2px) scale(1.05);
+    background-color: transparent;
 }
 
 #page-store .app-toggle-btn:hover .icon {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -16,7 +16,7 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 | Gris clair (texte secondaire) | `#B7B7C0` |
 | Gris placeholder (inputs) | `#5E5E66` |
 
-Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée en bas à droite de chaque tuile. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
+Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, positionnée sur la droite de chaque tuile sans aucun arrière‑plan. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
 Lorsqu'un utilisateur tente d'installer une application sans être connecté, une notification indique désormais « Veuillez vous connecter pour installer ».
 Un bref retour tactile confirme aussi l'installation ou la désinstallation sur les appareils compatibles.
 La liste déroulante des applications se ferme désormais en appuyant hors du menu ; la petite croix a été supprimée.


### PR DESCRIPTION
## Notes
- Les tests `npm test` échouent car `jest` n'est pas installé dans l'environnement d'exécution.

## Résumé
- bouton d'installation repositionné et sans fond dans `store-dark.css`
- documentation mise à jour pour refléter ce changement
- ajout d'une entrée dans le `changelog`

## Testing
- `npm test` *(échoue : jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853520fd754832e8dcc5bd9262cef64