### PR TITLE
Uniformisation des icônes de navigation

### DIFF
--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -18,7 +18,7 @@
         align-items: center;
     }
 
-    .bottom-nav .nav-icon {
+    .bottom-nav .app-icon {
         font-size: var(--font-size-md);
     }
 

--- a/css/icons.css
+++ b/css/icons.css
@@ -13,13 +13,15 @@
 }
 
 /* Icônes de navigation */
-.nav-icon .icon {
+.nav-link .app-icon .icon,
+.btn-logout .app-icon .icon {
     font-size: 1.1rem;
     margin-right: 0.5rem;
 }
 
 /* Icônes dans la sidebar minimaliste */
-.minimal-sidebar .nav-icon .icon {
+.minimal-sidebar .nav-link .app-icon .icon,
+.minimal-sidebar .btn-logout .app-icon .icon {
     font-size: 1.3rem;
     margin-right: 0;
 }
@@ -183,18 +185,11 @@
     .app-icon .icon {
         font-size: 1.8rem;
     }
-
-    .app-card .icon {
-        font-size: 2rem;
-    }
-
-    .app-actions .app-toggle-btn .icon {
-        font-size: 1.3rem;
-    }
-
-    .nav-icon .icon {
+    .nav-link .app-icon .icon,
+    .btn-logout .app-icon .icon {
         font-size: 1rem;
     }
+
 
     /* Couleur rouge de la poubelle en mode mobile */
     .app-toggle-btn.installed .icon,
@@ -262,7 +257,7 @@
 }
 
 .icon-button .icon,
-.nav-icon .icon {
+.app-icon .icon {
     transition: color 0.2s ease;
 }
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -106,7 +106,7 @@ body.sidebar-right .sidebar {
     background-color: white;
 }
 
-.nav-icon {
+.app-icon {
     font-size: var(--font-size-lg);
     min-width: 24px;
     text-align: center;

--- a/css/sidebar-c2r.css
+++ b/css/sidebar-c2r.css
@@ -45,7 +45,7 @@
     display: none;
 }
 
-.sidebar.sidebar-c2r .nav-icon {
+.sidebar.sidebar-c2r .app-icon {
     font-size: 26px;
     color: #b7b7c0;
     stroke-width: 2px;
@@ -61,8 +61,8 @@
     background-color: #26262f;
 }
 
-.sidebar.sidebar-c2r .nav-link.active .nav-icon,
-.sidebar.sidebar-c2r .nav-link:hover .nav-icon {
+.sidebar.sidebar-c2r .nav-link.active .app-icon,
+.sidebar.sidebar-c2r .nav-link:hover .app-icon {
     color: #ff5858;
 }
 

--- a/css/sidebar-minimal.css
+++ b/css/sidebar-minimal.css
@@ -47,7 +47,7 @@ body.minimal-sidebar .nav-text {
     display: none;
 }
 
-body.minimal-sidebar .nav-icon {
+body.minimal-sidebar .app-icon {
     font-size: var(--sidebar-icon-size);
     min-width: auto;
 }
@@ -117,7 +117,7 @@ body.minimal-sidebar .btn-logout .nav-text {
     display: none;
 }
 
-body.minimal-sidebar .btn-logout .nav-icon {
+body.minimal-sidebar .btn-logout .app-icon {
     font-size: var(--sidebar-icon-size);
 }
 
@@ -229,7 +229,7 @@ body.minimal-sidebar .btn-logout:active {
         display: block;
     }
     
-    body.minimal-sidebar .nav-icon {
+    body.minimal-sidebar .app-icon {
         font-size: var(--font-size-lg);
         min-width: 24px;
     }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -53,6 +53,7 @@ La barre latérale affiche un fond uni sans ombre pour s'intégrer aux thèmes s
 En affichage **PC**, la sidebar adopte désormais un style de tuile plus sobre sans barre de défilement verticale.
 
 Les textes des éléments disparaissent pour ne laisser que les icônes. Au passage de la souris, celles-ci se colorent en rouge et une info‑bulle identique apparaît pour chaque icône, qu'elle provienne du menu principal ou des applications. La règle `.sidebar-app-item:hover .app-icon` applique désormais explicitement la couleur `#ff5858` aux icônes des applications.
+Les icônes de la navigation utilisent désormais la même classe `app-icon` que celles des applications.
 
 ## Nouvelle barre latérale C2R
 La version sombre fixe adopte une largeur de 72 px. Son fond est uni (#0d0d12) sans bordure droite. Les icônes centrées changent de couleur au survol (#ff5858). Le logo "C2R" a été retiré et la police Montserrat est utilisée pour tout le contenu.

--- a/index.html
+++ b/index.html
@@ -35,31 +35,31 @@
         <ul class="nav-menu">
             <li class="nav-item">
                 <a href="#home" class="nav-link active" data-page="home" aria-label="Accueil">
-                    <span class="nav-icon" data-icon="home"></span>
+                    <span class="app-icon" data-icon="home"></span>
                     <span class="nav-text">Accueil</span>
                 </a>
             </li>
             <li class="nav-item">
                 <a href="#store" class="nav-link" data-page="store" aria-label="Store d'applications">
-                    <span class="nav-icon" data-icon="store"></span>
+                    <span class="app-icon" data-icon="store"></span>
                     <span class="nav-text">Store</span>
                 </a>
             </li>
             <li class="nav-item">
                 <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil utilisateur">
-                    <span class="nav-icon" data-icon="profile"></span>
+                    <span class="app-icon" data-icon="profile"></span>
                     <span class="nav-text">Profil</span>
                 </a>
             </li>
             <li class="nav-item">
                 <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
-                    <span class="nav-icon" data-icon="mail"></span>
+                    <span class="app-icon" data-icon="mail"></span>
                     <span class="nav-text">Contact</span>
                 </a>
             </li>
             <li class="nav-item admin-only" style="display: none;">
                 <a href="#admin" class="nav-link" data-page="admin" aria-label="Configuration administrateur">
-                    <span class="nav-icon" data-icon="admin"></span>
+                    <span class="app-icon" data-icon="admin"></span>
                     <span class="nav-text">Config</span>
                 </a>
             </li>
@@ -75,7 +75,7 @@
 
         <div class="sidebar-footer">
             <button class="btn-logout" id="logout-btn" aria-label="Se déconnecter">
-                <span class="nav-icon" data-icon="signout"></span>
+                <span class="app-icon" data-icon="signout"></span>
                 <span class="nav-text">Déconnexion</span>
             </button>
         </div>
@@ -343,19 +343,19 @@
     <!-- Barre de navigation mobile -->
     <nav class="bottom-nav mobile-only">
         <a href="#home" class="nav-link" data-page="home" aria-label="Accueil">
-            <span class="nav-icon" data-icon="home"></span>
+            <span class="app-icon" data-icon="home"></span>
         </a>
         <a href="#store" class="nav-link" data-page="store" aria-label="Store">
-            <span class="nav-icon" data-icon="store"></span>
+            <span class="app-icon" data-icon="store"></span>
         </a>
         <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil">
-            <span class="nav-icon" data-icon="profile"></span>
+            <span class="app-icon" data-icon="profile"></span>
         </a>
         <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
-            <span class="nav-icon" data-icon="mail"></span>
+            <span class="app-icon" data-icon="mail"></span>
         </a>
         <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
-            <span class="nav-icon" data-icon="list"></span>
+            <span class="app-icon" data-icon="list"></span>
         </button>
     </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -77,13 +77,13 @@ function updateConnectionStatus(isConnected) {
         if (isConnected) {
             btn.style.display = 'flex';
             btn.innerHTML = `
-                <span class="nav-icon">${IconManager.getIcon('signout')}</span>
+                <span class="app-icon">${IconManager.getIcon('signout')}</span>
                 <span class="nav-text">Déconnexion</span>
             `;
         } else {
             btn.style.display = 'flex';
             btn.innerHTML = `
-                <span class="nav-icon">${IconManager.getIcon('signout')}</span>
+                <span class="app-icon">${IconManager.getIcon('signout')}</span>
                 <span class="nav-text">Se connecter</span>
             `;
             btn.onclick = () => showAuthModal('login');


### PR DESCRIPTION
## Notes
- Remplacement des balises `<span class="nav-icon">` par `<span class="app-icon">` dans la page principale et la barre de navigation mobile.
- Mise à jour des scripts JavaScript associés et des styles CSS pour référencer `app-icon`.
- Fusion des règles d'icônes dans `icons.css` afin que la classe `app-icon` soit partagée par la navigation et les applications.
- Documentation complétée pour préciser cet usage commun.

## Tests
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_685352d59f24832e93b621cf2c69a711