### PR TITLE
Supprimer le fond sur hover de la sidebar

### DIFF
--- a/css/sidebar-c2r.css
+++ b/css/sidebar-c2r.css
@@ -53,9 +53,6 @@
 
 
 
-.sidebar.sidebar-c2r .nav-link:hover {
-    background-color: #2e2e38;
-}
 
 .sidebar.sidebar-c2r .nav-link.active {
     background-color: #26262f;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -56,3 +56,4 @@ Les textes des éléments disparaissent pour ne laisser que les icônes. Au pass
 
 ## Nouvelle barre latérale C2R
 La version sombre fixe adopte une largeur de 72 px. Son fond est uni (#0d0d12) sans bordure droite. Les icônes centrées changent de couleur au survol (#ff5858). Le logo "C2R" a été retiré et la police Montserrat est utilisée pour tout le contenu.
+Le survol n'affiche plus de fond gris : seules les icônes passent en rouge.


### PR DESCRIPTION
## Notes
- Jest n'a pas pu s'exécuter, l'environnement ne dispose pas de `jest`.

## Summary
- retire la couleur de fond au survol dans `sidebar-c2r.css`
- précise dans la doc UI que le survol conserve seulement la couleur rouge de l'icône

## Testing
- `npm test` *(échoue : jest introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_685352d6f92c832e885f5c96f10fc403