### PR TITLE
Retrait du titre Applications dans la sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Une vibration confirme désormais l'installation ou la désinstallation d'une application sur les appareils compatibles.
 - La barre latérale adopte désormais un fond uni sans ombre pour un rendu minimal.
 - En mode PC, la barre latérale adopte un style de tuile plus sobre, sans barre de défilement.
+- Le titre "Applications" n'apparaît plus dans la barre latérale pour gagner en clarté.
 - En mode bureau, elle ne comporte plus de texte : les icônes deviennent rouges au survol et une infobulle explique leur fonction.
 - En mode mobile, la barre latérale est désormais totalement masquée pour laisser la place à la navigation basse.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ s19smf-codex/2025-06-19
 
 ### ✨ En-tête épuré
 - Suppression de la bordure inférieure de la barre latérale pour retirer la séparation au-dessus de l'icône Accueil.
+- Suppression du titre "Applications" dans la barre latérale pour un design plus minimaliste.
 main
  main
 main

--- a/css/apps.css
+++ b/css/apps.css
@@ -6,14 +6,6 @@
     border-top: 1px solid var(--c2r-border);
 }
 
-.sidebar-section-title {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold);
-    color: var(--c2r-text-muted);
-    margin: 0 0 var(--c2r-spacing-sm) 0;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-}
 
 .sidebar-apps {
     display: flex;

--- a/css/global.css
+++ b/css/global.css
@@ -513,12 +513,6 @@ tr:last-child td {
     z-index: 100;
 }
 
-.installed-apps-sidebar h4 {
-    margin: 0 0 var(--c2r-spacing-md) 0;
-    color: var(--c2r-text);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold);
-}
 
 .installed-apps-list {
     display: flex;

--- a/css/sidebar-minimal.css
+++ b/css/sidebar-minimal.css
@@ -68,9 +68,6 @@ body.minimal-sidebar .sidebar-section {
     padding: 0 8px;
 }
 
-body.minimal-sidebar .sidebar-section-title {
-    display: none;
-}
 
 body.minimal-sidebar .sidebar-apps {
     display: flex;
@@ -238,9 +235,6 @@ body.minimal-sidebar .btn-logout:active {
         padding: 0;
     }
     
-    body.minimal-sidebar .sidebar-section-title {
-        display: block;
-    }
     
     body.minimal-sidebar .sidebar-app-item {
         justify-content: flex-start;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -21,6 +21,7 @@ Lorsqu'un utilisateur tente d'installer une application sans être connecté, un
 Un bref retour tactile confirme aussi l'installation ou la désinstallation sur les appareils compatibles.
 La liste déroulante des applications se ferme désormais en appuyant hors du menu ; la petite croix a été supprimée.
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
+Le titre "Applications" dans la barre latérale a également été supprimé pour un affichage épuré.
 
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store adopte un thème sombre rouge (fond `#0D0D12` avec dégradé `#15151B`).

--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
 
         <!-- Section Applications Installées -->
         <div class="sidebar-section user-only" style="display: none;">
-            <h4 class="sidebar-section-title">Applications</h4>
             <div class="sidebar-apps" id="sidebar-apps">
                 <!-- Applications installées -->
             </div>
@@ -417,7 +416,6 @@
 
     <!-- Section applications installées dans sidebar -->
     <div class="installed-apps-sidebar" id="installed-apps-sidebar">
-        <h4>Applications</h4>
         <div class="installed-apps-list" id="sidebar-apps-list">
             <!-- Applications installées générées dynamiquement -->
         </div>


### PR DESCRIPTION
## Résumé
- supprimer l'entête "Applications" dans la barre latérale
- adapter les styles associés
- mettre à jour la documentation
- journaliser le changement

## Test
- `npm test` *(échoue: UserCore.loadUsers undefined storage)*

------
https://chatgpt.com/codex/tasks/task_e_685356dab204832e8c7c7d64046d8d97