### PR TITLE
Suppression des fonds survol icônes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,40 +1,28 @@
 # 📝 C2R OS - Journal des modifications
 
-3o5ohn-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "NavIcons"
 
 ### 🎨 Icônes de navigation
 - Les icônes Accueil, Store, Profil et Contact reprennent le style des applications.
 - Aucun fond n'est appliqué lors du survol.
-=======
-d5es0y-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "ProfileCleanup"
 
 ### 🧹 Interface Profil
 - Suppression du titre "Applications installées" dans la page Profil pour un affichage plus épuré.
-=======
-4zpesh-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "IconManagerTest"
 
 ### ✅ Vérification d'injection
 - Ajout du test `tests/icon-manager.test.js` pour valider l'injection des icônes.
 
-=======
-s19smf-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "StoreButton"
 
 ### 🎨 Bouton du Store
 - Le bouton d'installation ne possède plus d'arrière-plan et se situe à présent sur la droite de chaque tuile.
-=======
 ## [1.1.25] - 2025-07-04 "NoHeaderLine"
 
 ### ✨ En-tête épuré
 - Suppression de la bordure inférieure de la barre latérale pour retirer la séparation au-dessus de l'icône Accueil.
 - Suppression du titre "Applications" dans la barre latérale pour un design plus minimaliste.
-main
- main
-main
-main
 
 ## [1.1.24] - 2025-07-03 "SidebarFlat"
 

--- a/css/apps.css
+++ b/css/apps.css
@@ -25,7 +25,7 @@
 }
 
 .sidebar-app-item:hover {
-    background-color: var(--c2r-bg-hover);
+    background-color: transparent;
     color: var(--c2r-text);
 }
 
@@ -277,5 +277,5 @@
 }
 
 .theme-dark .sidebar-app-item:hover {
-    background-color: var(--c2r-bg-hover);
+    background-color: transparent;
 }

--- a/css/icons.css
+++ b/css/icons.css
@@ -13,17 +13,16 @@
 }
 
 /* Icônes de navigation */
-3o5ohn-codex/2025-06-19
 .nav-icon .icon {
     font-size: 2rem;
     margin-right: 0.5rem;
     color: var(--primary-color);
-=======
+}
+
 .nav-link .app-icon .icon,
 .btn-logout .app-icon .icon {
     font-size: 1.1rem;
     margin-right: 0.5rem;
-main
 }
 
 /* Icônes dans la sidebar minimaliste */
@@ -192,7 +191,6 @@ main
     .app-icon .icon {
         font-size: 1.8rem;
     }
-3o5ohn-codex/2025-06-19
 
     .app-card .icon {
         font-size: 2rem;
@@ -204,11 +202,10 @@ main
 
     .nav-icon .icon {
         font-size: 1.8rem;
-=======
+    }
     .nav-link .app-icon .icon,
     .btn-logout .app-icon .icon {
         font-size: 1rem;
-main
     }
 
 

--- a/css/sidebar-c2r.css
+++ b/css/sidebar-c2r.css
@@ -53,12 +53,10 @@
 
 
 
-3o5ohn-codex/2025-06-19
+
 .sidebar.sidebar-c2r .nav-link:hover {
     background-color: transparent;
 }
-=======
-main
 
 .sidebar.sidebar-c2r .nav-link.active {
     background-color: #26262f;
@@ -86,6 +84,6 @@ main
 }
 
 .sidebar.sidebar-c2r .btn-logout:hover {
-    background-color: #2e2e38;
+    background-color: transparent;
     color: #ff5858;
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -54,11 +54,8 @@ La barre latérale affiche un fond uni sans ombre pour s'intégrer aux thèmes s
 En affichage **PC**, la sidebar adopte désormais un style de tuile plus sobre sans barre de défilement verticale.
 
 Les textes des éléments disparaissent pour ne laisser que les icônes. Au passage de la souris, celles-ci se colorent en rouge et une info‑bulle identique apparaît pour chaque icône, qu'elle provienne du menu principal ou des applications. La règle `.sidebar-app-item:hover .app-icon` applique désormais explicitement la couleur `#ff5858` aux icônes des applications.
-3o5ohn-codex/2025-06-19
 - Les icônes Accueil, Store, Profil et Contact adoptent la même taille et la même couleur que celles des applications, sans fond au survol.
-=======
 Les icônes de la navigation utilisent désormais la même classe `app-icon` que celles des applications.
-main
 
 ## Nouvelle barre latérale C2R
 La version sombre fixe adopte une largeur de 72 px. Son fond est uni (#0d0d12) sans bordure droite. Les icônes centrées changent de couleur au survol (#ff5858). Le logo "C2R" a été retiré et la police Montserrat est utilisée pour tout le contenu.


### PR DESCRIPTION
## Notes
- suppression des marqueurs `codex` dans la documentation et les feuilles de style
- nettoyage des doublons dans `changelog.md`
- retrait de l'arrière‑plan au survol pour les icônes (sidebar et applications)
- mises à jour des fichiers CSS et docs correspondants

## Tests
- `npm test` *(1 échec connu)*

------
https://chatgpt.com/codex/tasks/task_e_685358881390832e9bb7256c7986e888