### PR TITLE
Ajustement du bouton Install dans le Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 - Une section **Contact** intégrée dans `index.html` permet d'envoyer un message à `contact@c2ros.com`.
 - La documentation de cette section se trouve dans [`docs/contact-readme.md`](docs/contact-readme.md).
 
-Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
+Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées en bas à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
 
-- Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge, positionnée sur la droite de chaque tuile sans aucun arrière-plan.
-- Les icônes d'installation sont centrées sur la droite des tuiles pour plus de clarté et ne possèdent aucun fond.
+- Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge, placée en bas à droite de chaque tuile sans aucun arrière-plan.
+- Les icônes d'installation sont positionnées en bas à droite des tuiles pour plus de clarté et ne possèdent aucun fond.
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
 - En mode mobile, la poubelle s'affiche désormais en rouge grâce à une règle CSS dédiée.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.

--- a/changelog.md
+++ b/changelog.md
@@ -1,40 +1,28 @@
 # 📝 C2R OS - Journal des modifications
 
-3o5ohn-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "NavIcons"
 
 ### 🎨 Icônes de navigation
 - Les icônes Accueil, Store, Profil et Contact reprennent le style des applications.
 - Aucun fond n'est appliqué lors du survol.
-=======
-d5es0y-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "ProfileCleanup"
 
 ### 🧹 Interface Profil
 - Suppression du titre "Applications installées" dans la page Profil pour un affichage plus épuré.
-=======
-4zpesh-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "IconManagerTest"
 
 ### ✅ Vérification d'injection
 - Ajout du test `tests/icon-manager.test.js` pour valider l'injection des icônes.
 
-=======
-s19smf-codex/2025-06-19
 ## [1.1.25] - 2025-07-04 "StoreButton"
 
 ### 🎨 Bouton du Store
-- Le bouton d'installation ne possède plus d'arrière-plan et se situe à présent sur la droite de chaque tuile.
-=======
+- Le bouton d'installation ne possède plus d'arrière-plan et se situe désormais en bas à droite de chaque tuile.
 ## [1.1.25] - 2025-07-04 "NoHeaderLine"
 
 ### ✨ En-tête épuré
 - Suppression de la bordure inférieure de la barre latérale pour retirer la séparation au-dessus de l'icône Accueil.
 - Suppression du titre "Applications" dans la barre latérale pour un design plus minimaliste.
-main
- main
-main
-main
 
 ## [1.1.24] - 2025-07-03 "SidebarFlat"
 

--- a/css/icons.css
+++ b/css/icons.css
@@ -13,17 +13,15 @@
 }
 
 /* Icônes de navigation */
-3o5ohn-codex/2025-06-19
 .nav-icon .icon {
     font-size: 2rem;
     margin-right: 0.5rem;
     color: var(--primary-color);
-=======
+}
 .nav-link .app-icon .icon,
 .btn-logout .app-icon .icon {
     font-size: 1.1rem;
     margin-right: 0.5rem;
-main
 }
 
 /* Icônes dans la sidebar minimaliste */
@@ -192,7 +190,6 @@ main
     .app-icon .icon {
         font-size: 1.8rem;
     }
-3o5ohn-codex/2025-06-19
 
     .app-card .icon {
         font-size: 2rem;
@@ -204,11 +201,10 @@ main
 
     .nav-icon .icon {
         font-size: 1.8rem;
-=======
+    }
     .nav-link .app-icon .icon,
     .btn-logout .app-icon .icon {
         font-size: 1rem;
-main
     }
 
 

--- a/css/sidebar-c2r.css
+++ b/css/sidebar-c2r.css
@@ -51,14 +51,9 @@
     stroke-width: 2px;
 }
 
-
-
-3o5ohn-codex/2025-06-19
 .sidebar.sidebar-c2r .nav-link:hover {
     background-color: transparent;
 }
-=======
-main
 
 .sidebar.sidebar-c2r .nav-link.active {
     background-color: #26262f;

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -124,9 +124,9 @@ body.theme-dark {
     align-items: center;
     justify-content: center;
     position: absolute;
-    top: 50%;
+    bottom: 16px;
     right: 16px;
-    transform: translateY(-50%);
+    transform: none;
     margin-top: 0;
     width: auto;
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -16,7 +16,7 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 | Gris clair (texte secondaire) | `#B7B7C0` |
 | Gris placeholder (inputs) | `#5E5E66` |
 
-Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, positionnée sur la droite de chaque tuile sans aucun arrière‑plan. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
+Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, placée en bas à droite de chaque tuile sans aucun arrière‑plan. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
 Lorsqu'un utilisateur tente d'installer une application sans être connecté, une notification indique désormais « Veuillez vous connecter pour installer ».
 Un bref retour tactile confirme aussi l'installation ou la désinstallation sur les appareils compatibles.
 La liste déroulante des applications se ferme désormais en appuyant hors du menu ; la petite croix a été supprimée.
@@ -54,11 +54,8 @@ La barre latérale affiche un fond uni sans ombre pour s'intégrer aux thèmes s
 En affichage **PC**, la sidebar adopte désormais un style de tuile plus sobre sans barre de défilement verticale.
 
 Les textes des éléments disparaissent pour ne laisser que les icônes. Au passage de la souris, celles-ci se colorent en rouge et une info‑bulle identique apparaît pour chaque icône, qu'elle provienne du menu principal ou des applications. La règle `.sidebar-app-item:hover .app-icon` applique désormais explicitement la couleur `#ff5858` aux icônes des applications.
-3o5ohn-codex/2025-06-19
 - Les icônes Accueil, Store, Profil et Contact adoptent la même taille et la même couleur que celles des applications, sans fond au survol.
-=======
 Les icônes de la navigation utilisent désormais la même classe `app-icon` que celles des applications.
-main
 
 ## Nouvelle barre latérale C2R
 La version sombre fixe adopte une largeur de 72 px. Son fond est uni (#0d0d12) sans bordure droite. Les icônes centrées changent de couleur au survol (#ff5858). Le logo "C2R" a été retiré et la police Montserrat est utilisée pour tout le contenu.


### PR DESCRIPTION
## Résumé
- place le bouton d'installation des tuiles en bas à droite
- met à jour la documentation en français
- nettoie les délimitations de fusion indésirables

## Tests
- `npm test` *(échoue : jest ne trouve pas UserCore)*

------
https://chatgpt.com/codex/tasks/task_e_685358d32b90832eb6bc1fb60cc6cc93