### PR TITLE
Ajuste margin store mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 - Le Store adopte un mode sombre rouge (fond #0D0D12 avec dégradé #15151B).
 - Les tuiles du Store reprennent désormais le format des cartes d'accueil : icône au-dessus du texte et disposition en liste.
+- Sur mobile, chaque tuile occupe toute la largeur de l'écran avec une petite marge latérale.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -204,4 +204,8 @@ body.theme-dark {
     #page-store .apps-grid {
         flex-direction: column;
     }
+
+    #page-store .app-card {
+        margin: 0 var(--c2r-spacing-sm);
+    }
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -26,7 +26,7 @@ Le titre "Applications" dans la barre latérale a également été supprimé pou
 La barre de recherche du Store se masque automatiquement lors du défilement vers le bas.
 Le Store adopte un thème sombre rouge (fond `#0D0D12` avec dégradé `#15151B`).
 Les tuiles reprennent le format des cartes d'accueil : icône au-dessus du texte et disposition en liste verticale.
-Sur mobile, chaque tuile occupe désormais toute la largeur de l'écran.
+Sur mobile, chaque tuile occupe toute la largeur de l'écran avec une petite marge latérale.
 La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.


### PR DESCRIPTION
## Notes
- ajustement CSS pour marge sur les tuiles en version mobile
- précision dans la documentation concernant la largeur des tuiles sur mobile

## Testing
- `npm test` *(échoue : jest manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68541140e828832e8cc609a10975ef07