### PR TITLE
Ajustement mobile du Store

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -604,7 +604,7 @@ body.sidebar-right .sidebar {
     
     
     .main-content {
-        padding: calc(80px + var(--c2r-spacing-md)) var(--c2r-spacing-md) calc(80px + var(--c2r-spacing-md));
+        padding: calc(80px + var(--c2r-spacing-md)) 0 calc(80px + var(--c2r-spacing-md));
     }
     
     .page-header {
@@ -647,7 +647,7 @@ body.sidebar-right .sidebar {
 
 @media (max-width: 480px) {
     .main-content {
-        padding: calc(80px + var(--c2r-spacing-sm)) var(--c2r-spacing-sm) calc(80px + var(--c2r-spacing-sm));
+        padding: calc(80px + var(--c2r-spacing-sm)) 0 calc(80px + var(--c2r-spacing-sm));
     }
     
     .welcome-card {

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -199,6 +199,17 @@ body.theme-dark {
 
 
 @media (max-width: 768px) {
+    #page-store {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    #page-store .store-controls {
+        margin-left: 0;
+    }
+    #page-store .search-container,
+    #page-store select {
+        width: 100%;
+    }
     #page-store .apps-grid {
         grid-template-columns: 1fr;
     }
@@ -209,6 +220,17 @@ body.theme-dark {
 }
 
 @media (max-width: 600px) {
+    #page-store {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    #page-store .store-controls {
+        margin-left: 0;
+    }
+    #page-store .search-container,
+    #page-store select {
+        width: 100%;
+    }
     #page-store .apps-grid {
         grid-template-columns: 1fr;
     }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -28,6 +28,9 @@ Le Store adopte un thème sombre rouge (fond `#0D0D12` avec dégradé `#15151B`)
 Les tuiles reprennent le format des cartes d'accueil : icône au-dessus du texte et disposition en liste verticale.
 Les applications sont désormais regroupées dans une grande carte qui contient toutes ces tuiles.
 Sur mobile, chaque tuile occupe toute la largeur de l'écran avec une petite marge latérale.
+La page Store n'a plus de marge latérale en mode mobile afin d'exploiter toute la largeur disponible.
+Le contenu principal n'a plus de marge horizontale sur mobile pour permettre au Store d'occuper la largeur totale de l'écran.
+La barre de recherche et les filtres du Store s'étendent désormais sur toute la largeur en mode mobile.
 La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évitant son affichage sur les autres pages.
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
@@ -57,6 +60,7 @@ En affichage **PC**, la sidebar adopte désormais un style de tuile plus sobre s
 Les textes des éléments disparaissent pour ne laisser que les icônes. Au passage de la souris, celles-ci se colorent en rouge et une info‑bulle identique apparaît pour chaque icône, qu'elle provienne du menu principal ou des applications. La règle `.sidebar-app-item:hover .app-icon` applique désormais explicitement la couleur `#ff5858` aux icônes des applications.
 - Les icônes Accueil, Store, Profil et Contact adoptent la même taille et la même couleur que celles des applications, sans fond au survol.
 Les icônes de la navigation utilisent désormais la même classe `app-icon` que celles des applications.
+- Tous les fichiers Markdown ont été vérifiés et ne comportent plus de marqueurs de conflit Git.
 
 ## Nouvelle barre latérale C2R
 La version sombre fixe adopte une largeur de 72 px. Son fond est uni (#0d0d12) sans bordure droite. Les icônes centrées changent de couleur au survol (#ff5858). Le logo "C2R" a été retiré et la police Montserrat est utilisée pour tout le contenu.


### PR DESCRIPTION
## Summary
- retirer l'espace latéral du contenu principal sur mobile
- préciser dans la documentation que la page Store utilise toute la largeur sur petit écran

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854637b292c832e90d6fa313b673eb0