### PR TITLE
Ajout d'un bouton Admin dans la barre mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
 - En mode mobile, la poubelle s'affiche désormais en rouge grâce à une règle CSS dédiée.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
+- Si vous êtes connecté en administrateur, une icône supplémentaire donne accès à la gestion des comptes.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - En mode mobile, la liste des applications se referme si l'on touche un autre bouton de la barre.
 - La barre de navigation mobile mesure maintenant 80px de haut pour une meilleure ergonomie.

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -33,6 +33,7 @@ La page Store reste masquée tant qu'elle ne porte pas la classe `active`, évit
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 Depuis la version 1.1.8, cette barre mesure 80px de haut pour faciliter la navigation tactile.
 Lorsque l'on presse un autre bouton de cette barre, la liste d'applications se referme automatiquement.
+Si l'utilisateur connecté possède le rôle *admin*, un bouton supplémentaire apparaît pour ouvrir la page de configuration administrateur.
 La barre latérale est désormais désactivée sur mobile pour laisser toute la place à la navigation basse.
 Les icônes du menu mobile reprennent la même taille que celles utilisées dans la page Profil pour une cohérence visuelle.
 Les icônes du menu mobile sont encore plus petites afin d'optimiser l'espace disponible.

--- a/index.html
+++ b/index.html
@@ -354,6 +354,9 @@
         <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
             <span class="app-icon" data-icon="mail"></span>
         </a>
+        <a href="#admin" class="nav-link admin-only" data-page="admin" aria-label="Configuration" style="display: none;">
+            <span class="app-icon" data-icon="admin"></span>
+        </a>
         <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
             <span class="app-icon" data-icon="list"></span>
         </button>


### PR DESCRIPTION
## Résumé
- icône *admin* sur la navigation mobile pour gérer les comptes
- doc UI mise à jour avec la présence de ce bouton pour les administrateurs
- README complété

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c523e592c832eb70cb96058bd4ab0