### PR TITLE
Fix chess app store integration

### DIFF
--- a/apps/chess/app.js
+++ b/apps/chess/app.js
@@ -50,7 +50,43 @@ function initGame () {
   updateStatus();
 }
 
-document.addEventListener('DOMContentLoaded', initGame);
+async function loadScript (src) {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${src}"]`);
+    if (existing) {
+      existing.addEventListener('load', resolve);
+      if (existing.complete) resolve();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = src;
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+async function loadDependencies () {
+  const promises = [];
+  if (typeof Chess === 'undefined') {
+    promises.push(loadScript('https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js'));
+  }
+  if (typeof Chessboard === 'undefined') {
+    promises.push(loadScript('https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard.min.js'));
+  }
+  await Promise.all(promises);
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    await loadDependencies();
+    initGame();
+  } catch (error) {
+    console.error('Erreur chargement dépendances échiquier:', error);
+    const statusEl = document.getElementById('chess-status');
+    if (statusEl) statusEl.textContent = 'Erreur de chargement';
+  }
+});
 
 function saveAiEndpoint () {
   const input = document.getElementById('ai-endpoint');

--- a/docs/chess-readme.md
+++ b/docs/chess-readme.md
@@ -6,3 +6,7 @@ Ouvrez simplement `chess.html` pour démarrer une partie contre un adversaire hu
 
 Vous pouvez aussi cliquer sur la tuile « Jouer aux échecs » depuis la page d'accueil pour ouvrir ce même échiquier dans un nouvel onglet.
 Les pièces se déplacent comme sur un vrai plateau. L'IA joue automatiquement si vous avez configuré son URL.
+
+## Version intégrée au Store
+
+Le Store inclut également ce jeu dans la liste des applications disponibles. Lors de son lancement depuis la modale, `AppCore` charge `app.html`, `app.css` et `app.js`. Ce dernier récupère désormais **chess.js** et **chessboard.js** de manière dynamique afin de garantir le bon fonctionnement de l'échiquier. Une connexion Internet reste nécessaire pour charger ces bibliothèques hébergées sur CDN.


### PR DESCRIPTION
## Summary
- load chessboard.js and chess.js dynamically for the store version
- document store integration in chess README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5687d448832ea97d87ece0eb670e