### PR TITLE
Ajout de la connexion administrateur aux comptes utilisateurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - Si vous êtes connecté en administrateur, une icône supplémentaire donne accès à la gestion des comptes.
 - Depuis ce panneau, l'administrateur peut ajouter ou supprimer des utilisateurs, consulter leur nom d'utilisateur et le hash de leur mot de passe. Les logs système sont visibles dans les options avancées.
+- Un administrateur peut se connecter temporairement sous l'identité d'un autre utilisateur depuis ce tableau.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - En mode mobile, la liste des applications se referme si l'on touche un autre bouton de la barre.
 - La barre de navigation mobile mesure maintenant 80px de haut pour une meilleure ergonomie.

--- a/docs/user-readme.md
+++ b/docs/user-readme.md
@@ -6,3 +6,4 @@ préférences de chaque utilisateur et assure la persistance des données via
 première connexion.
 
 Depuis le panneau d'administration, un bouton permet désormais d'ajouter un nouvel utilisateur via la fenêtre d'inscription. Les administrateurs peuvent aussi supprimer des comptes existants et consulter le nom d'utilisateur ainsi que le hash des mots de passe enregistrés dans le tableau des utilisateurs.
+Ils disposent également d'une option **Se connecter** pour prendre temporairement l'identité d'un utilisateur et revenir ensuite à leur session initiale.

--- a/index.html
+++ b/index.html
@@ -239,9 +239,12 @@
                     <button class="btn btn-secondary" id="clear-cache-user" aria-label="Vider le cache">
                         Vider le cache
                     </button>
-                        <button class="btn btn-secondary btn-logout" id="logout-btn-profile" aria-label="Se déconnecter">
-                            Déconnexion
-                        </button>
+                    <button class="btn btn-primary" id="back-admin-btn" style="display:none;" aria-label="Retour administrateur">
+                        Retour Admin
+                    </button>
+                    <button class="btn btn-secondary btn-logout" id="logout-btn-profile" aria-label="Se déconnecter">
+                        Déconnexion
+                    </button>
                 </div>
             </div>
         </section>

--- a/js/modules/ui/icon-manager.js
+++ b/js/modules/ui/icon-manager.js
@@ -10,6 +10,7 @@
         check: '<i class="icon fa-solid fa-check"></i>',
         list: '<i class="icon fa-solid fa-list"></i>',
         signout: '<i class="icon fa-solid fa-right-from-bracket"></i>',
+        login: '<i class="icon fa-solid fa-right-to-bracket"></i>',
         search: '<i class="icon fa-solid fa-magnifying-glass"></i>',
         idea: '<i class="icon fa-solid fa-lightbulb"></i>',
         refresh: '<i class="icon fa-solid fa-arrows-rotate"></i>',


### PR DESCRIPTION
## Résumé
- possibilité pour un administrateur de se connecter temporairement sous un autre compte
- bouton *Retour Admin* dans la page Profil
- nouvelles méthodes `impersonateUser` et `stopImpersonation` dans `UserCore` et `UICore`
- mise à jour de l'icôné graphique et de la documentation

## Tests
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c5b10aa20832e8ae12ce769c8c5de