### PR TITLE
Mise à jour version et page d'accueil

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.28] - 2025-07-07 "VersionBump"
+
+### 🚀 Mise à jour de version
+- Mise à jour de la version et de la date d'actualisation sur la page d'accueil.
+
 ## [1.1.27] - 2025-07-06 "ChessRemoval"
 
 ### 🔥 Suppression de la page Échecs

--- a/docs/agents/home-AGENTS.md
+++ b/docs/agents/home-AGENTS.md
@@ -6,3 +6,4 @@ Ce fichier décrit la conduite à suivre pour maintenir la page d'accueil :
 - Utiliser un design épuré et responsive basé sur HTML, CSS et JavaScript.
 - Veiller à la cohérence visuelle avec les autres pages.
 - Mettre ce fichier à jour dès qu'une nouvelle fonctionnalité est ajoutée.
+- Mettre à jour la version et la date d'actualisation sur la page d'accueil à chaque modification du dépôt.

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <div class="welcome-card">
                 <div class="welcome-header">
                     <h1>Bienvenue sur C2R OS</h1>
-                    <p class="system-version">C2R OS v1.0.0 – Build 2025-05-27</p>
+                    <p class="system-version">C2R OS v1.1.28 – Build 2025-07-07</p>
                     <p class="update-time text-small">Mis à jour le <span id="update-time"></span></p>
                 </div>
                 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 /**
  * C2R OS - Point d'entrée principal
- * Version: 1.0.0
+ * Version: 1.1.28
  * Description: Système d'exploitation dans le navigateur avec architecture modulaire
  */
 
@@ -940,7 +940,7 @@ window.C2R_DEBUG = {
 
 // Message de bienvenue développeur
 console.log(`
-🎯 C2R OS v1.0.0 "Genesis" - Développement
+🎯 C2R OS v1.1.28 "Genesis" - Développement
 ┌─────────────────────────────────────────┐
 │ 🔧 Mode Debug activé                   │
 │ 💻 Tapez C2R_DEBUG pour les utilitaires│

--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -1,14 +1,14 @@
 /**
  * C2R OS - Configuration centrale
  * Module: CoreConfig
- * Version: 1.0.0
+ * Version: 1.1.28
  * Description: Configuration globale du système C2R OS
  */
 
 class CoreConfig {
     constructor() {
-        this.version = "1.0.0";
-        this.build = "2025-05-27";
+        this.version = "1.1.28";
+        this.build = "2025-07-07";
         this.codename = "Genesis";
         
         // Configuration système

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.0",
-  "build": "2025-05-27",
+  "version": "1.1.28",
+  "build": "2025-07-07",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Résumé
- incrémentation de la version du système (1.1.28)
- mise à jour de la date de build
- ajout d'une entrée de changelog
- actualisation de la page d'accueil et du message développeur
- documentation de la mise à jour dans `home-AGENTS.md`

## Tests
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c657c63d8832e89ff59bb82c031d8