### PR TITLE
Ajout d'un bouton de mise à jour PWA dans le profil

### DIFF
--- a/docs/agents/profile-AGENTS.md
+++ b/docs/agents/profile-AGENTS.md
@@ -6,3 +6,4 @@ Consignes pour la gestion de la page Profil :
 - Autoriser le réordonnancement des applications par glisser-déposer.
 - Garantir l'accessibilité sur mobile et ordinateur.
 - Mettre ce fichier à jour dès qu'un nouveau réglage est introduit.
+- Ajouter un bouton "Mise à jour" permettant de rafraîchir l'application en mode PWA.

--- a/docs/profile-readme.md
+++ b/docs/profile-readme.md
@@ -13,3 +13,4 @@ fond s'assombrit pour mieux la distinguer. Sur smartphone, une courte vibration
 signale le début et la fin du déplacement.
 Un bouton de déconnexion est disponible pour terminer la session.
 Les préférences incluent plusieurs options : activer ou désactiver les notifications, choisir le mode sombre et déplacer la barre de navigation.
+Un bouton "Mise à jour" permet de rafraîchir l'application lorsqu'elle est installée en PWA.

--- a/index.html
+++ b/index.html
@@ -234,6 +234,9 @@
                     <button class="btn btn-secondary" id="clear-cache-user" aria-label="Vider le cache">
                         Vider le cache
                     </button>
+                    <button class="btn btn-primary" id="pwa-update" aria-label="Mise à jour">
+                        Mise à jour
+                    </button>
                     <button class="btn btn-primary" id="back-admin-btn" style="display:none;" aria-label="Retour administrateur">
                         Retour Admin
                     </button>

--- a/js/main.js
+++ b/js/main.js
@@ -136,6 +136,12 @@ function setupGlobalEventHandlers() {
     if (userCacheBtn) {
         userCacheBtn.addEventListener('click', handleClearCache);
     }
+
+    // Bouton de mise à jour PWA
+    const pwaUpdateBtn = document.getElementById('pwa-update');
+    if (pwaUpdateBtn) {
+        pwaUpdateBtn.addEventListener('click', handlePWAUpdate);
+    }
     
     // Gestionnaires de drag & drop pour réorganiser les apps
     setupDragAndDrop();
@@ -560,6 +566,19 @@ function displayUpdateTime() {
     if (el) {
         const now = new Date();
         el.textContent = now.toLocaleString();
+    }
+}
+
+/**
+ * Mettre à jour l'application PWA
+ */
+function handlePWAUpdate() {
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations()
+            .then(regs => regs.forEach(reg => reg.update()))
+            .finally(() => location.reload());
+    } else {
+        location.reload();
     }
 }
 


### PR DESCRIPTION
## Résumé
- ajout d'un bouton "Mise à jour" sur la page Profil pour rafraîchir l'application PWA
- gestionnaire JavaScript `handlePWAUpdate` pour mettre à jour les Service Workers puis recharger la page
- documentation mise à jour pour décrire cette nouvelle fonctionnalité

## Tests
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c6727a870832e8059bbfcba920f3c