### PR TITLE
Réduction et mise en blanc des icônes du store

### DIFF
--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -83,8 +83,8 @@ body.theme-dark {
 }
 
 #page-store .app-icon {
-    width: 48px;
-    height: 48px;
+    width: 32px;
+    height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -97,8 +97,8 @@ body.theme-dark {
 }
 
 #page-store .app-icon .icon {
-    font-size: 48px;
-    color: #c53a3a;
+    font-size: 32px;
+    color: #ffffff;
     transition: all 180ms ease-in-out;
 }
 

--- a/docs/agents/store-AGENTS.md
+++ b/docs/agents/store-AGENTS.md
@@ -8,3 +8,4 @@ Directives pour gérer la page du Store :
 - Mettre ce fichier à jour à chaque ajout ou modification d'application.
 - Le nom de l'application s'affiche dans la barre rouge translucide, à droite de l'icône.
 - L'icône d'installation ou de suppression est placée en bas à droite de la tuile.
+- Les icônes des applications doivent être affichées en blanc avec une taille réduite.


### PR DESCRIPTION
## Résumé
- diminution de la taille des icônes dans `css/store-dark.css`
- icônes du store désormais en blanc
- ajout de la directive correspondante dans `docs/agents/store-AGENTS.md`

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c713384dc832e954404ab394ce935