### PR TITLE
Ajout de test et amélioration de la mise à jour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@
 ### 🚀 Mise à jour de version
 - Mise à jour de la version et de la date d'actualisation sur la page d'accueil.
 
+## [1.1.29] - 2025-07-08 "ProfileUpdate"
+
+### ✨ Notification de mise à jour
+- Le bouton "Mise à jour" de la page Profil affiche une pastille lorsque `version.json` indique une nouvelle version.
+
 ## [1.1.27] - 2025-07-06 "ChessRemoval"
 
 ### 🔥 Suppression de la page Échecs

--- a/css/global.css
+++ b/css/global.css
@@ -156,6 +156,18 @@ p {
     min-height: 48px;
 }
 
+/* Indicateur de mise à jour pour les boutons */
+.btn.update-available::after {
+    content: '';
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 10px;
+    height: 10px;
+    background-color: var(--c2r-warning);
+    border-radius: 50%;
+}
+
 /* Formulaires */
 input,
 textarea,

--- a/docs/agents/profile-AGENTS.md
+++ b/docs/agents/profile-AGENTS.md
@@ -7,3 +7,5 @@ Consignes pour la gestion de la page Profil :
 - Garantir l'accessibilité sur mobile et ordinateur.
 - Mettre ce fichier à jour dès qu'un nouveau réglage est introduit.
 - Ajouter un bouton "Mise à jour" permettant de rafraîchir l'application en mode PWA.
+- Afficher une notification visuelle sur ce bouton lorsqu'une nouvelle version est disponible.
+- Vérifier régulièrement `version.json` sans cache pour détecter les mises à jour.

--- a/docs/profile-readme.md
+++ b/docs/profile-readme.md
@@ -13,4 +13,4 @@ fond s'assombrit pour mieux la distinguer. Sur smartphone, une courte vibration
 signale le début et la fin du déplacement.
 Un bouton de déconnexion est disponible pour terminer la session.
 Les préférences incluent plusieurs options : activer ou désactiver les notifications, choisir le mode sombre et déplacer la barre de navigation.
-Un bouton "Mise à jour" permet de rafraîchir l'application lorsqu'elle est installée en PWA.
+Un bouton "Mise à jour" permet de rafraîchir l'application lorsqu'elle est installée en PWA. Une pastille apparaît sur ce bouton pour prévenir l'utilisateur lorsqu'une nouvelle version est détectée. Le fichier `version.json` est récupéré sans cache afin de signaler immédiatement la disponibilité d'une mise à jour.

--- a/js/main.js
+++ b/js/main.js
@@ -63,6 +63,7 @@ function initializeUserInterface() {
     }
 
     displayUpdateTime();
+    checkVersionUpdate();
 }
 
 /**
@@ -573,12 +574,45 @@ function displayUpdateTime() {
  * Mettre à jour l'application PWA
  */
 function handlePWAUpdate() {
+    const uiCore = window.C2R_SYSTEM?.uiCore;
+    if (uiCore) {
+        uiCore.showNotification('Mise à jour en cours...', 'info');
+    }
+
     if ('serviceWorker' in navigator) {
         navigator.serviceWorker.getRegistrations()
             .then(regs => regs.forEach(reg => reg.update()))
             .finally(() => location.reload());
     } else {
         location.reload();
+    }
+}
+
+/**
+ * Vérifier si une nouvelle version est disponible
+ */
+function checkVersionUpdate() {
+    fetch('version.json', { cache: 'no-cache' })
+        .then(resp => resp.json())
+        .then(data => {
+            const stored = localStorage.getItem('c2ros_version');
+            if (stored && stored !== data.version) {
+                markUpdateAvailable();
+                window.C2R_SYSTEM?.uiCore?.showNotification('Nouvelle version disponible', 'info');
+            }
+            localStorage.setItem('c2ros_version', data.version);
+        })
+        .catch(err => console.error('Erreur vérification version:', err));
+}
+
+/**
+ * Marquer le bouton de mise à jour comme ayant une nouvelle version
+ */
+function markUpdateAvailable() {
+    const btn = document.getElementById('pwa-update');
+    if (btn) {
+        btn.classList.add('update-available');
+        btn.style.overflow = 'visible';
     }
 }
 

--- a/tests/version-update.test.js
+++ b/tests/version-update.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Fonctions de mise à jour', () => {
+  beforeAll(() => {
+    document.body.innerHTML = '<button id="pwa-update" class="btn"></button>';
+    window.fetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ version: '1.2.0' })
+    }));
+    const script = fs.readFileSync(path.resolve(__dirname, '../js/main.js'), 'utf8');
+    window.eval(script);
+  });
+
+  test('markUpdateAvailable applique la classe', () => {
+    window.markUpdateAvailable();
+    const btn = document.getElementById('pwa-update');
+    expect(btn.classList.contains('update-available')).toBe(true);
+    expect(btn.style.overflow).toBe('visible');
+  });
+
+  test('checkVersionUpdate stocke la version', async () => {
+    localStorage.setItem('c2ros_version', '1.1.0');
+    window.checkVersionUpdate();
+    await new Promise(process.nextTick);
+    expect(localStorage.getItem('c2ros_version')).toBe('1.2.0');
+  });
+});


### PR DESCRIPTION
## Résumé
- vérifie `version.json` sans cache pour détecter les nouvelles versions
- affiche correctement la pastille de notification grâce à `overflow: visible`
- documente cette vérification dans le profil et son AGENTS
- décrit la fonctionnalité dans le changelog
- ajoute des tests Jest pour `markUpdateAvailable` et `checkVersionUpdate`

## Tests
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c715d2518832eaf0c2934b7959df8