### PR TITLE
Ajout de l'historique de modifications

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.30] - 2025-07-09 "HomeHistory"
+
+### 🆕 Historique des modifications
+- Ajout d'une tuile sur la page d'accueil affichant les trois dernières mises à jour.
 ## [1.1.29] - 2025-07-08 "WindowButtons"
 
 ### ✨ Harmonisation des contrôles

--- a/css/layout.css
+++ b/css/layout.css
@@ -246,6 +246,15 @@ body.sidebar-right .sidebar {
     color: var(--c2r-text-secondary);
 }
 
+.changelog-list {
+    list-style: none;
+    padding: 0;
+    margin: var(--c2r-spacing-md) 0 0 0;
+    text-align: left;
+    color: var(--c2r-text-secondary);
+    font-size: var(--font-size-sm);
+}
+
 .daily-tip {
     background-color: var(--c2r-bg-secondary);
     border: 1px solid var(--c2r-border);

--- a/docs/agents/home-AGENTS.md
+++ b/docs/agents/home-AGENTS.md
@@ -7,3 +7,4 @@ Ce fichier décrit la conduite à suivre pour maintenir la page d'accueil :
 - Veiller à la cohérence visuelle avec les autres pages.
 - Mettre ce fichier à jour dès qu'une nouvelle fonctionnalité est ajoutée.
 - Mettre à jour la version et la date d'actualisation sur la page d'accueil à chaque modification du dépôt.
+- Afficher dans une tuile dédiée les trois dernières modifications avec leur date et heure.

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <div class="welcome-card">
                 <div class="welcome-header">
                     <h1>Bienvenue sur C2R OS</h1>
-                    <p class="system-version">C2R OS v1.1.29 – Build 2025-07-08</p>
+                    <p class="system-version">C2R OS v1.1.30 – Build 2025-07-09</p>
                     <p class="update-time text-small">Mis à jour le <span id="update-time"></span></p>
                 </div>
                 
@@ -126,6 +126,11 @@
                             <h3>Infos sur les applications</h3>
                             <p>Découvrez les différents types d'applications disponibles et accédez directement au catalogue.</p>
                         </a>
+                        <div class="card info-tile" id="changelog-tile">
+                            <span data-icon="history"></span>
+                            <h3>Dernières modifications</h3>
+                            <ul id="changelog-list" class="changelog-list"></ul>
+                        </div>
                     </div>
 
                     <div id="daily-tip" class="daily-tip">

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 /**
  * C2R OS - Point d'entrée principal
- * Version: 1.1.29
+ * Version: 1.1.30
  * Description: Système d'exploitation dans le navigateur avec architecture modulaire
  */
 
@@ -993,7 +993,7 @@ window.C2R_DEBUG = {
 
 // Message de bienvenue développeur
 console.log(`
-🎯 C2R OS v1.1.29 "Genesis" - Développement
+🎯 C2R OS v1.1.30 "Genesis" - Développement
 ┌─────────────────────────────────────────┐
 │ 🔧 Mode Debug activé                   │
 │ 💻 Tapez C2R_DEBUG pour les utilitaires│

--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -1,14 +1,14 @@
 /**
  * C2R OS - Configuration centrale
  * Module: CoreConfig
- * Version: 1.1.29
+ * Version: 1.1.30
  * Description: Configuration globale du système C2R OS
  */
 
 class CoreConfig {
     constructor() {
-        this.version = "1.1.29";
-        this.build = "2025-07-08";
+        this.version = "1.1.30";
+        this.build = "2025-07-09";
         this.codename = "Genesis";
         
         // Configuration système

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -538,6 +538,9 @@ class UICore {
     refreshHomePage() {
         // Mettre à jour le conseil du jour
         this.updateDailyTip();
+
+        // Mettre à jour la liste des modifications récentes
+        this.updateChangelogTile();
         
         // Mettre à jour les informations de version
         const config = window.C2R_SYSTEM?.config;
@@ -927,6 +930,25 @@ class UICore {
         if (container) {
             container.style.display = enabled ? 'flex' : 'none';
         }
+    }
+
+    /**
+     * Mettre à jour la tuile des modifications récentes
+     */
+    updateChangelogTile() {
+        fetch('recent-changes.json')
+            .then(r => r.json())
+            .then(data => {
+                const list = document.getElementById('changelog-list');
+                if (!list) return;
+                list.innerHTML = '';
+                data.slice(0, 3).forEach(item => {
+                    const li = document.createElement('li');
+                    li.textContent = `${item.datetime} – ${item.description}`;
+                    list.appendChild(li);
+                });
+            })
+            .catch(err => console.error('Erreur chargement changelog:', err));
     }
 
     /**

--- a/recent-changes.json
+++ b/recent-changes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "version": "1.1.30",
+    "datetime": "2025-07-09 12:00",
+    "description": "Tuile historique sur la page d'accueil"
+  },
+  {
+    "version": "1.1.29",
+    "datetime": "2025-07-08 14:20",
+    "description": "Harmonisation des contrôles"
+  },
+  {
+    "version": "1.1.29",
+    "datetime": "2025-07-08 10:10",
+    "description": "Notification de mise à jour"
+  }
+]

--- a/tests/changelog-tile.test.js
+++ b/tests/changelog-tile.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('updateChangelogTile', () => {
+  beforeAll(() => {
+    document.body.innerHTML = '<ul id="changelog-list"></ul>';
+    window.fetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve([
+        { datetime: '2025-07-09 12:00', description: 'test' }
+      ])
+    }));
+
+    const configScript = fs.readFileSync(
+      path.resolve(__dirname, '../js/modules/core/config.js'),
+      'utf8'
+    );
+    const uiScript = fs.readFileSync(
+      path.resolve(__dirname, '../js/modules/ui/ui-core.js'),
+      'utf8'
+    );
+    window.eval(configScript);
+    window.eval(uiScript);
+  });
+
+  test('affiche les modifications', async () => {
+    const ui = new window.UICore();
+    ui.updateChangelogTile();
+    await new Promise(process.nextTick);
+    const list = document.getElementById('changelog-list');
+    expect(list.children.length).toBe(1);
+    expect(list.textContent).toContain('test');
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.29",
-  "build": "2025-07-08",
+  "version": "1.1.30",
+  "build": "2025-07-09",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Résumé
- nouvelle tuile "Dernières modifications" sur la page d'accueil
- style dédié et chargement dynamique depuis `recent-changes.json`
- mise à jour de la configuration et de la version (1.1.30)
- entrée correspondante dans `changelog.md`
- nouveaux tests pour `updateChangelogTile`

## Test
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c779339c4832ea33af7e4dd39f80c