### PR TITLE
Ajout vibration mobile sur notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,6 @@ Ce dépôt contient un ensemble d'applications et de pages web modulaires. Les i
 - Chaque application située dans `apps/` doit posséder son propre `AGENTS.md` suivant le même modèle.
 - **Aucun délimiteur de conflit Git** ne doit apparaître dans ces fichiers.
 - Mettez à jour systématiquement les fichiers `AGENTS.md` pour refléter les dernières fonctionnalités et choix techniques.
+- Sur mobile, chaque notification doit déclencher une courte vibration pour informer l'utilisateur.
 - Les boutons de contrôle des fenêtres (fermer, agrandir, réduire) utilisent les symboles « × », « □ » et « − » sans arrière‑plan.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.30] - 2025-07-09 "NotificationVibration"
+
+### 📳 Retour tactile sur notifications
+- En mode mobile, chaque notification provoque une courte vibration du smartphone.
 ## [1.1.29] - 2025-07-08 "WindowButtons"
 
 ### ✨ Harmonisation des contrôles

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -19,6 +19,7 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, positionnée en bas à droite de chaque tuile, centrée et sans aucun arrière‑plan. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une règle CSS dédiée garantit que la poubelle reste rouge sur mobile.
 Lorsqu'un utilisateur tente d'installer une application sans être connecté, une notification indique désormais « Veuillez vous connecter pour installer ».
 Un bref retour tactile confirme aussi l'installation ou la désinstallation sur les appareils compatibles.
+En mode mobile, chaque notification déclenche également une courte vibration pour attirer l'attention.
 La liste déroulante des applications se ferme désormais en appuyant hors du menu ; la petite croix a été supprimée.
 Le titre "Applications installées" a été retiré pour gagner de la place et les icônes y sont affichées en plus petit.
 Le titre "Applications" dans la barre latérale a également été supprimé pour un affichage épuré.

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <div class="welcome-card">
                 <div class="welcome-header">
                     <h1>Bienvenue sur C2R OS</h1>
-                    <p class="system-version">C2R OS v1.1.29 – Build 2025-07-08</p>
+                    <p class="system-version">C2R OS v1.1.30 – Build 2025-07-09</p>
                     <p class="update-time text-small">Mis à jour le <span id="update-time"></span></p>
                 </div>
                 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 /**
  * C2R OS - Point d'entrée principal
- * Version: 1.1.29
+ * Version: 1.1.30
  * Description: Système d'exploitation dans le navigateur avec architecture modulaire
  */
 
@@ -993,7 +993,7 @@ window.C2R_DEBUG = {
 
 // Message de bienvenue développeur
 console.log(`
-🎯 C2R OS v1.1.29 "Genesis" - Développement
+🎯 C2R OS v1.1.30 "Genesis" - Développement
 ┌─────────────────────────────────────────┐
 │ 🔧 Mode Debug activé                   │
 │ 💻 Tapez C2R_DEBUG pour les utilitaires│

--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -1,14 +1,14 @@
 /**
  * C2R OS - Configuration centrale
  * Module: CoreConfig
- * Version: 1.1.29
+ * Version: 1.1.30
  * Description: Configuration globale du système C2R OS
  */
 
 class CoreConfig {
     constructor() {
-        this.version = "1.1.29";
-        this.build = "2025-07-08";
+        this.version = "1.1.30";
+        this.build = "2025-07-09";
         this.codename = "Genesis";
         
         // Configuration système

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -1169,6 +1169,11 @@ class UICore {
         `;
         
         container.appendChild(notification);
+
+        // Vibration courte sur mobile
+        if (window.innerWidth <= 768 && navigator.vibrate) {
+            navigator.vibrate(100);
+        }
         
         // Animation d'entrée
         setTimeout(() => {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.29",
-  "build": "2025-07-08",
+  "version": "1.1.30",
+  "build": "2025-07-09",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Résumé
- retour tactile sur mobile lors de l'affichage d'une notification
- documentation du comportement dans `ui-readme.md`
- nouvelle directive dans `AGENTS.md`
- mise à jour de la version vers **1.1.30**
- mise à jour de la page d'accueil et de la configuration centrale
- ajout du journal correspondant dans `changelog.md`

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c77efae6c832ea5b2b45c1b0b87ca