### PR TITLE
Ajout d'une mise à jour automatique du conseil du jour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,4 +9,5 @@ Ce dépôt contient un ensemble d'applications et de pages web modulaires. Les i
 - **Aucun délimiteur de conflit Git** ne doit apparaître dans ces fichiers.
 - Mettez à jour systématiquement les fichiers `AGENTS.md` pour refléter les dernières fonctionnalités et choix techniques.
 - Les boutons de contrôle des fenêtres (fermer, agrandir, réduire) utilisent les symboles « × », « □ » et « − » sans arrière‑plan.
+- La tuile « Conseil du jour » doit changer à chaque chargement de la page d'accueil en intégrant les fonctionnalités récentes.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
   2. **Options du profil** — la tuile ouvre directement la page correspondante pour activer ou désactiver les notifications, passer en mode sombre ou déplacer la barre de navigation.
   3. **Installer C2R OS** — un bouton permet d'ajouter l'application sur smartphone en mode PWA.
   4. **Infos sur les applications** — cette tuile renvoie directement au Store pour découvrir les différents types d'apps disponibles.
+- Une tuile "Conseil du jour" affiche aléatoirement une astuce en fonction des fonctionnalités présentes dans `version.json` et se met à jour à chaque chargement de la page.
 - Les applications internes utilisent désormais uniquement les icônes Font Awesome pour un style unifié.
 - L'application **Notes Vocales** permet d'enregistrer votre voix et de la transcrire via Whisper.
 - Sur mobile, l'application peut s'installer en plein écran grâce au fichier `manifest.webmanifest`.

--- a/docs/agents/home-AGENTS.md
+++ b/docs/agents/home-AGENTS.md
@@ -7,3 +7,4 @@ Ce fichier décrit la conduite à suivre pour maintenir la page d'accueil :
 - Veiller à la cohérence visuelle avec les autres pages.
 - Mettre ce fichier à jour dès qu'une nouvelle fonctionnalité est ajoutée.
 - Mettre à jour la version et la date d'actualisation sur la page d'accueil à chaque modification du dépôt.
+- La tuile "Conseil du jour" doit afficher aléatoirement une astuce issue des fonctions listées dans `version.json` et être rafraîchie à chaque chargement de la page.

--- a/index.html
+++ b/index.html
@@ -441,6 +441,7 @@
     <script src="js/modules/ui/ui-core.js"></script>
     <script src="js/modules/profile/profile-system.js"></script>
     <script src="js/modules/system/system-integration.js"></script>
+    <script src="js/data/daily-tips.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 
     <!-- Point d'entrée principal -->

--- a/js/data/daily-tips.js
+++ b/js/data/daily-tips.js
@@ -1,0 +1,9 @@
+window.C2R_STATIC_TIPS = [
+    "Explorez les nouvelles applications disponibles dans le Store pour enrichir votre expérience.",
+    "Vous pouvez réorganiser vos applications installées par glisser-déposer dans la section Profil.",
+    "Le thème sombre peut être activé ou désactivé à tout moment dans vos préférences.",
+    "Les administrateurs ont accès à des outils de gestion avancés dans la section Configuration.",
+    "Utilisez la barre de recherche du Store pour trouver rapidement les applications dont vous avez besoin.",
+    "Personnalisez votre expérience en modifiant la position de la barre latérale.",
+    "Vos préférences sont automatiquement sauvegardées à chaque modification."
+];

--- a/js/main.js
+++ b/js/main.js
@@ -62,6 +62,13 @@ function initializeUserInterface() {
         }, 1000);
     }
 
+    // Mettre à jour le conseil du jour dès le chargement
+    if (uiCore.updateDailyTip) {
+        uiCore.updateDailyTip().catch(err =>
+            console.error('Erreur mise à jour du conseil :', err)
+        );
+    }
+
     displayUpdateTime();
     checkVersionUpdate();
 }

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -535,9 +535,9 @@ class UICore {
     /**
      * Rafraîchir la page d'accueil
      */
-    refreshHomePage() {
+    async refreshHomePage() {
         // Mettre à jour le conseil du jour
-        this.updateDailyTip();
+        await this.updateDailyTip();
         
         // Mettre à jour les informations de version
         const config = window.C2R_SYSTEM?.config;
@@ -553,17 +553,21 @@ class UICore {
     /**
      * Mettre à jour le conseil du jour
      */
-    updateDailyTip() {
-        const tips = [
-            "Explorez les nouvelles applications disponibles dans le Store pour enrichir votre expérience.",
-            "Vous pouvez réorganiser vos applications installées par glisser-déposer dans la section Profil.",
-            "Le thème sombre peut être activé/désactivé à tout moment dans vos préférences.",
-            "Les administrateurs ont accès à des outils de gestion avancés dans la section Configuration.",
-            "Utilisez la barre de recherche du Store pour trouver rapidement les applications dont vous avez besoin.",
-            "Personnalisez votre expérience en modifiant la position de la barre latérale.",
-            "Vos préférences sont automatiquement sauvegardées à chaque modification."
-        ];
-        
+    async updateDailyTip() {
+        const staticTips = window.C2R_STATIC_TIPS || [];
+        let featureTips = [];
+
+        try {
+            const resp = await fetch('version.json', { cache: 'no-cache' });
+            const data = await resp.json();
+            if (Array.isArray(data.features)) {
+                featureTips = data.features.map(f => `Nouveauté : ${f}.`);
+            }
+        } catch (error) {
+            console.error('Erreur chargement des fonctionnalités :', error);
+        }
+
+        const tips = staticTips.concat(featureTips);
         const randomTip = tips[Math.floor(Math.random() * tips.length)];
         const tipElement = document.querySelector('#daily-tip p');
         if (tipElement) {

--- a/tests/daily-tip.test.js
+++ b/tests/daily-tip.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('UICore.updateDailyTip', () => {
+  beforeAll(async () => {
+    // Charger les scripts nécessaires
+    const configScript = fs.readFileSync(path.resolve(__dirname, '../js/modules/core/config.js'), 'utf8');
+    window.eval(configScript);
+    const tipsScript = fs.readFileSync(path.resolve(__dirname, '../js/data/daily-tips.js'), 'utf8');
+    window.eval(tipsScript);
+    const uiScript = fs.readFileSync(path.resolve(__dirname, '../js/modules/ui/ui-core.js'), 'utf8');
+    window.fetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ features: ['Test dynamique'] })
+    }));
+    document.body.innerHTML = '<div id="daily-tip"><p></p></div>';
+    window.eval(uiScript);
+  });
+
+  test('affiche un conseil aléatoire', async () => {
+    const ui = new window.UICore();
+    await ui.updateDailyTip();
+    const text = document.querySelector('#daily-tip p').textContent;
+    expect(text.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Résumé
- actualisation du "Conseil du jour" dès le chargement de l’interface
- mise à jour de la documentation pour préciser le comportement dynamique
- rappel de cette exigence dans le fichier d’agent de la page d’accueil

## Tests
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c7875c928832e9a47728985ab31ad