### PR TITLE
Alignement des tuiles du Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Les tuiles du Store reprennent désormais le format des cartes d'accueil : icône au-dessus du texte et disposition en liste.
 - Toutes ces tuiles sont maintenant regroupées dans une grande carte afin de mieux structurer la page Store.
 - Les tuiles s'alignent automatiquement sur plusieurs colonnes pour occuper toute la largeur disponible.
+- Les tuiles sont centrées dans la grande carte avec une marge identique de chaque côté.
 - Sur mobile, chaque tuile occupe toute la largeur de l'écran avec une petite marge latérale.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un court retour haptique est émis sur smartphone au début et à la fin du déplacement.

--- a/css/store-dark.css
+++ b/css/store-dark.css
@@ -29,12 +29,16 @@ body.theme-dark {
     border-radius: var(--c2r-radius);
     box-shadow: var(--c2r-shadow-lg);
     padding: var(--c2r-spacing-lg);
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 #page-store .apps-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
     gap: var(--c2r-spacing-lg);
+    justify-content: center;
 }
 
 #page-store .app-card {

--- a/docs/agents/store-AGENTS.md
+++ b/docs/agents/store-AGENTS.md
@@ -9,3 +9,4 @@ Directives pour gérer la page du Store :
 - Le nom de l'application s'affiche dans la barre rouge translucide, à droite de l'icône.
 - L'icône d'installation ou de suppression est placée en bas à droite de la tuile.
 - Les icônes des applications doivent être affichées en blanc avec une taille réduite.
+- Les tuiles doivent être centrées dans la grande carte avec une marge latérale identique et minimale.


### PR DESCRIPTION
## Résumé
- centrer la grille des applications au sein de la carte principale
- préciser la règle de centrage dans `store-AGENTS.md`
- documenter la mise à jour de l'alignement dans `README.md`

## Tests
- `npm test` *(échoue : jest non trouvé)*
- `npx jest` *(échec : installation bloquée)*

------
https://chatgpt.com/codex/tasks/task_e_685c7efd09f8832e830aba6787a71352