### PR TITLE
Correction bouton Enregistrer pour Notes Vocales

### DIFF
--- a/apps/voicenotes/AGENTS.md
+++ b/apps/voicenotes/AGENTS.md
@@ -6,3 +6,6 @@
 - La fonction d'enregistrement doit vérifier la disponibilité du microphone et
   gérer les erreurs d'autorisation.
 - Les pistes audio doivent être libérées dès la fin de l'enregistrement.
+- L'initialisation est déclenchée immédiatement si le DOM est déjà prêt afin
+  que le bouton **Enregistrer** fonctionne dans les applications chargées
+  dynamiquement.

--- a/apps/voicenotes/app.js
+++ b/apps/voicenotes/app.js
@@ -120,4 +120,9 @@ async function transcribeWithWhisper(blob) {
     }
 }
 
-document.addEventListener('DOMContentLoaded', initVoiceNotes);
+// Initialiser l'application dès que possible
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initVoiceNotes);
+} else {
+    initVoiceNotes();
+}


### PR DESCRIPTION
## Résumé
- initialise l'application *Notes Vocales* immédiatement si le DOM est déjà chargé
- met à jour `AGENTS.md` de l'application pour décrire ce comportement

## Résultats des tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c7f48236c832eb31d7195f28db829