### PR TITLE
Correction de la date affichée

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # 📝 C2R OS - Journal des modifications
-## [1.1.31] - 2025-07-10 "UpdateDate"
+## [1.1.31] - 2025-06-25 "UpdateDate"
 
 ### 🔮 Mise à jour de la date de version
 - Actualisation de la date affichée sur la page d'accueil

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <div class="welcome-card">
                 <div class="welcome-header">
                     <h1>Bienvenue sur C2R OS</h1>
-                    <p class="system-version">C2R OS v1.1.31 – Build 2025-07-10</p>
+                    <p class="system-version">C2R OS v1.1.31 – Build 2025-06-25</p>
                     <p class="update-time text-small">Mis à jour le <span id="update-time"></span></p>
                 </div>
                 

--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -8,7 +8,7 @@
 class CoreConfig {
     constructor() {
         this.version = "1.1.31";
-        this.build = "2025-07-10";
+        this.build = "2025-06-25";
         this.codename = "Genesis";
         
         // Configuration système

--- a/recent-changes.json
+++ b/recent-changes.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "1.1.31",
-    "datetime": "2025-07-10 12:00",
+    "datetime": "2025-06-25 12:00",
     "description": "Mise à jour de la date sur la page d'accueil"
   },
   {

--- a/tests/changelog-tile.test.js
+++ b/tests/changelog-tile.test.js
@@ -6,7 +6,7 @@ describe('updateChangelogTile', () => {
     document.body.innerHTML = '<ul id="changelog-list"></ul>';
     window.fetch = jest.fn(() => Promise.resolve({
       json: () => Promise.resolve([
-        { datetime: '2025-07-10 12:00', description: 'test' }
+        { datetime: '2025-06-25 12:00', description: 'test' }
       ])
     }));
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1.31",
-  "build": "2025-07-10",
+  "build": "2025-06-25",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Résumé
- mise à jour de la date de build dans toutes les sources
- ajustement du changelog et des tests en conséquence

## Tests
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_685c84ab7db0832e8a0a3f0d4069d369