### PR TITLE
Correction du chargement du jeu d'échecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode mobile, la barre latérale est désormais totalement masquée pour laisser la place à la navigation basse.
 - Les icônes Accueil, Store, Profil et Contact reprennent le même design que celles des applications et ne prennent plus de fond au survol.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
- - Le jeu d'échecs repose désormais sur le script local `simple-chess.js` qui gère l'affichage et les règles. Un menu permet de choisir un moteur IA et de renseigner son URL. Sans configuration, un robot local joue aléatoirement.
+ - Le jeu d'échecs repose désormais sur le script local `simple-chess.js` qui gère l'affichage et les règles. Le fichier est chargé dynamiquement pour éviter toute erreur lors de l'ouverture. Un menu permet de choisir un moteur IA et de renseigner son URL. Sans configuration, un robot local joue aléatoirement.
  - Le jeu d'échecs s'installe depuis le Store et se lance dans une modale dédiée.
 - La page d'accueil propose quatre tuiles pour comprendre le fonctionnement de C2R OS :
   1. **Installez des applications IA et services** — la tuile elle-même mène directement au Store et les applications installées apparaissent dans la barre de navigation.
@@ -89,4 +89,4 @@ Les tests couvrent la gestion des icônes via `IconManager`.
 
 ## Jeu d'échecs
 
-Pour jouer, installez l'application depuis le Store. L'échiquier est entièrement géré en local via `simple-chess.js`.
+Pour jouer, installez l'application depuis le Store. L'échiquier est entièrement géré en local via `simple-chess.js`. Ce script est désormais ajouté dynamiquement par `app.js` afin d'éviter l'erreur de chargement.

--- a/apps/chess/AGENTS.md
+++ b/apps/chess/AGENTS.md
@@ -11,3 +11,5 @@
 - Un robot local joue aléatoirement lorsque c'est au tour des noirs.
 - L'initialisation se déclenche automatiquement même si le script est injecté
   après l'événement `DOMContentLoaded` afin d'éviter l'écran noir.
+- Le fichier `simple-chess.js` est désormais chargé dynamiquement par
+  `loadDependencies()` afin d'éviter l'erreur "Erreur de chargement".

--- a/apps/chess/app.html
+++ b/apps/chess/app.html
@@ -1,15 +1,5 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>Chess</title>
-  <link rel="stylesheet" href="app.css">
-  <script src="simple-chess.js"></script>
-  <script src="app.js" defer></script>
-</head>
-<body>
+<div class="chess-app">
   <h1>Chess</h1>
   <div id="board"></div>
   <div id="chess-status" class="chess-status"></div>
-</body>
-</html>
+</div>

--- a/apps/chess/app.js
+++ b/apps/chess/app.js
@@ -115,7 +115,17 @@ function initGame () {
 }
 
 function loadDependencies () {
-  return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    if (window.SimpleChess) {
+      resolve();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'apps/chess/simple-chess.js';
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Erreur chargement simple-chess.js'));
+    document.head.appendChild(script);
+  });
 }
 
 async function startChess() {

--- a/docs/chess-readme.md
+++ b/docs/chess-readme.md
@@ -1,9 +1,9 @@
 # Application d'échecs
 
-Le mode autonome a été retiré. Le jeu s'ouvre uniquement depuis le Store. L'échiquier est géré par un script local `simple-chess.js` sans dépendance externe.
+Le mode autonome a été retiré. Le jeu s'ouvre uniquement depuis le Store. L'échiquier est géré par un script local `simple-chess.js` sans dépendance externe. Ce script est chargé dynamiquement par `app.js` pour garantir son exécution.
 
 Les pièces se déplacent comme sur un vrai plateau. L'IA joue automatiquement si vous avez configuré son URL.
 
 ## Version intégrée au Store
 
-Le Store inclut également ce jeu dans la liste des applications disponibles. Lors de son lancement depuis la modale, `AppCore` charge `app.html`, `app.css`, `simple-chess.js` et `app.js`. Aucune connexion n'est requise pour jouer car toutes les ressources sont embarquées.
+Le Store inclut également ce jeu dans la liste des applications disponibles. Lors de son lancement depuis la modale, `AppCore` charge `app.html`, `app.css` et `app.js`. Le fichier `simple-chess.js` est ensuite ajouté par la fonction `loadDependencies()`. Aucune connexion n'est requise pour jouer car toutes les ressources sont embarquées.


### PR DESCRIPTION
## Résumé
- évite l'erreur « Erreur de chargement » dans l'application Échecs
- charge `simple-chess.js` dynamiquement dans `app.js`
- simplifie `app.html` en extrait HTML
- documente la modification dans `README.md`, `docs/chess-readme.md` et `apps/chess/AGENTS.md`

## Tests
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685cdfb1b908832ebf9b5c37f35a97ee