### PR TITLE
feat(chess): import modules & explicit mount; fix base path; expose mount

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Ce dépôt contient un ensemble d'applications et de pages web modulaires. Les i
 - Les boutons de contrôle des fenêtres (fermer, agrandir, réduire) utilisent les symboles « × », « □ » et « − » sans arrière‑plan.
 - Les ressources sont résolues dynamiquement pour GitHub Pages et les scripts sont chargés en modules ES.
 - Le Store charge les applications en important explicitement leurs modules ES puis en montant l'interface correspondante. L'app « Échecs Pro » est initialisée via `mountChessPro` avec des journaux de debug.
+- Un overlay de débogage activé par `?debug=1` capture tous les journaux console.
 
 
 ## Plateforme d'echecs moderne

--- a/apps/chess/AGENTS.md
+++ b/apps/chess/AGENTS.md
@@ -4,7 +4,8 @@
 - Utiliser HTML, CSS et JavaScript en modules ES.
 - Documenter toute nouvelle fonctionnalité directement dans ce fichier.
 - Tous les chemins restent **relatifs** pour compatibilité GitHub Pages.
-- Un garde global empêche le double montage lorsque le module est chargé plusieurs fois.
+- Un garde global `__C2R_CHESS_EXPOSED` et l'attribut `root.__mounted` empêchent tout double montage.
+- `mountChessPro` est exposé sur `window` pour un appel explicite par le Store.
 - Le Store importe `engine.js` et `chess.js` comme modules ES, puis appelle explicitement `mountChessPro(root)` après injection du HTML.
 - Chaque étape de chargement est tracée dans la console et les chemins respectent le préfixe GitHub Pages.
 

--- a/apps/chess/chess.js
+++ b/apps/chess/chess.js
@@ -1,10 +1,6 @@
 import { makeStart, parseFEN, toFEN, legalMoves, isCheckmate, isStalemate, san, applyMove, Color } from './engine.js';
 
-if (window.__C2R_CHESS_MOUNTED) {
-  // déjà importé quelque part : on laisse le loader appeler mount
-} else {
-  window.__C2R_CHESS_MOUNTED = true;
-}
+if (!window.__C2R_CHESS_EXPOSED){ window.__C2R_CHESS_EXPOSED = true; }
 
 export function mountChessPro(root){
   if (!root || root.__mounted) return;
@@ -120,6 +116,8 @@ export function mountChessPro(root){
 
   render();
 }
+
+if (typeof window !== 'undefined') { window.mountChessPro = mountChessPro; }
 
 // Auto-mount si chess.html est chargé tel quel
 document.addEventListener('DOMContentLoaded', ()=>{

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.36] - 2025-08-09 "ChessMount"
+
+### ♟️ Correctifs Échecs Pro
+- Overlay de débogage activé via `?debug=1` capturant les journaux.
+- Import explicite des modules et montage manuel de `mountChessPro(root)`.
+- Levée du blocage des clics grâce aux règles CSS `pointer-events`.
+
 ## [1.1.35] - 2025-08-08 "ChessLoader"
 
 ### ♟️ Chargement explicite des modules

--- a/css/global.css
+++ b/css/global.css
@@ -624,3 +624,7 @@ body[data-info-popups='disabled'] .notifications-container {
         width: calc(100% - 40px);
     }
 }
+
+.c2r-window .content, .c2r-chess-pro { pointer-events:auto; }
+.c2r-modal-backdrop { pointer-events:none; }
+

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,71 @@
+window.C2R_DEBUG = window.C2R_DEBUG || /[?&]debug=1\b/.test(location.search);
+(function initDebugOverlay(){
+  if (!window.C2R_DEBUG || document.getElementById('c2r-debug')) return;
+  const pre = document.createElement('pre');
+  pre.id = 'c2r-debug';
+  pre.style.cssText = 'position:fixed;left:0;right:0;bottom:0;max-height:40vh;overflow:auto;margin:0;padding:8px;background:rgba(0,0,0,.85);color:#0f0;font:12px monospace;z-index:999999;pointer-events:none;white-space:pre-wrap;';
+  document.body.appendChild(pre);
+  const log = (...a)=>{ pre.textContent += a.map(v=> typeof v==='object'? JSON.stringify(v): String(v)).join(' ') + '\n'; };
+  ['log','info','warn','error','debug'].forEach(k=>{ const o=console[k].bind(console); console[k]=(...a)=>{ o(...a); log(`[${k.toUpperCase()}]`, ...a); }; });
+})();
+
+function getBasePath(){ const p=location.pathname; return p.endsWith('/')? p : p.replace(/\/[^/]*$/, '/'); }
+function resolveURL(p){
+  if (!p) return p;
+  if (/^https?:\/\//i.test(p)) return p;
+  const base = new URL(getBasePath(), location.origin);
+  return new URL(p.replace(/^\//,''), base).href;
+}
+function ensureStyle(href){
+  const url = resolveURL(href);
+  if ([...document.styleSheets].some(s => s.href && (s.href === url || s.href.endsWith(href)))) return;
+  const link = document.createElement('link'); link.rel='stylesheet'; link.href=url; document.head.appendChild(link);
+}
+async function importModule(path){
+  const url = resolveURL(path);
+  console.debug('[Loader] import', url);
+  return await import(/* @vite-ignore */ url);
+}
+
+async function openApp(app){
+  try{
+    console.info('[Loader] openApp', app?.id || app?.name, app);
+
+    // 1) Styles
+    (app.styles || []).forEach(ensureStyle);
+
+    // 2) HTML
+    const entryUrl = resolveURL(app.entry);
+    console.debug('[Loader] fetch HTML', entryUrl);
+    const html = await fetch(entryUrl).then(r => { if(!r.ok) throw new Error(`HTTP ${r.status} on ${entryUrl}`); return r.text(); });
+
+    // 3) Conteneur
+    const container = getAppContainer(app); // ta fonction existante
+    container.innerHTML = html;
+
+    // 4) Importer les modules (les <script> dans innerHTML ne s’exécutent PAS)
+    const mods = [];
+    for (const m of (app.scripts || [])) mods.push(await importModule(m));
+
+    // 5) Monter explicitement
+    const main  = mods.at(-1) || {};
+    const mount = main.mountChessPro || window.mountChessPro;
+    const root  = container.querySelector('.c2r-chess-pro');
+    console.debug('[Loader] mount?', !!mount, 'root?', !!root);
+
+    if (typeof mount === 'function' && root){
+      if (!root.__mounted){ root.__mounted = true; mount(root); }
+      console.info('[Loader] mounted OK');
+    } else {
+      console.warn('[Loader] mountChessPro introuvable OU .c2r-chess-pro manquant');
+    }
+
+    // 6) Afficher fenêtre/modale
+    showAppWindow(container);
+  } catch(e){
+    console.error('[Loader] openApp failed', e);
+    alert('Échec lancement Échecs Pro : ' + e.message);
+  }
+}
+
+window.C2R_APP_LOADER = { openApp };


### PR DESCRIPTION
## Résumé
- ajout d'un loader global avec overlay de débogage, résolution des chemins et montage explicite de `mountChessPro`
- exposition de `mountChessPro` côté client avec garde anti double-montage
- règles CSS pour rétablir les clics sur la fenêtre et l'échiquier

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689705586b68832ea45885a8914ba594