### PR TITLE
Corrige le montage d'Échecs Pro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Ce dépôt contient un ensemble d'applications et de pages web modulaires. Les i
 - Les boutons de contrôle des fenêtres (fermer, agrandir, réduire) utilisent les symboles « × », « □ » et « − » sans arrière‑plan.
 - Les ressources sont résolues dynamiquement pour GitHub Pages et les scripts sont chargés en modules ES.
 - Le Store charge les applications en important explicitement leurs modules ES puis en montant l'interface correspondante. L'app « Échecs Pro » est initialisée via `mountChessPro` avec des journaux de debug.
+- Le chargeur marque `root.__mounted` seulement après l'exécution réussie de `mountChessPro` afin d'activer l'échiquier et les boutons.
 - Un overlay de débogage activé par `?debug=1` capture tous les journaux console.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.37] - 2025-08-09 "MountFlag"
+
+### ♟️ Correctifs Échecs Pro
+- Le chargeur définit `root.__mounted` après l'appel à `mountChessPro`, assurant l'affichage de l'échiquier et l'activation des boutons.
+
 ## [1.1.36] - 2025-08-09 "ChessMount"
 
 ### ♟️ Correctifs Échecs Pro

--- a/js/app.js
+++ b/js/app.js
@@ -54,7 +54,10 @@ async function openApp(app){
     console.debug('[Loader] mount?', !!mount, 'root?', !!root);
 
     if (typeof mount === 'function' && root){
-      if (!root.__mounted){ root.__mounted = true; mount(root); }
+      if (!root.__mounted){
+        mount(root);
+        root.__mounted = true;
+      }
       console.info('[Loader] mounted OK');
     } else {
       console.warn('[Loader] mountChessPro introuvable OU .c2r-chess-pro manquant');

--- a/recent-changes.json
+++ b/recent-changes.json
@@ -1,4 +1,14 @@
 [{
+    "version": "1.1.37",
+    "datetime": "2025-08-09 12:00",
+    "description": "Le chargeur attend la fin de mountChessPro avant de marquer l'app montée"
+  },
+  {
+    "version": "1.1.36",
+    "datetime": "2025-08-09 12:00",
+    "description": "Overlay de debug et montée explicite de mountChessPro"
+  },
+  {
     "version": "1.1.35",
     "datetime": "2025-08-08 12:00",
     "description": "Import explicite des modules pour Échecs Pro"
@@ -27,15 +37,5 @@
     "version": "1.1.30",
     "datetime": "2025-07-09 12:00",
     "description": "Tuile historique sur la page d'accueil"
-  },
-  {
-    "version": "1.1.29",
-    "datetime": "2025-07-08 14:20",
-    "description": "Harmonisation des contrôles"
-  },
-  {
-    "version": "1.1.29",
-    "datetime": "2025-07-08 10:10",
-    "description": "Notification de mise à jour"
   }
 ]


### PR DESCRIPTION
## Résumé
- évite de marquer l'échiquier comme monté avant l'appel à `mountChessPro`
- documente le comportement du chargeur dans `AGENTS.md`
- consigne la correction dans le changelog et l'historique

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979f8c13fc832ea6a8b73e0378d59a