### PR TITLE
Intégrer la vitrine à l'OS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,16 @@ Ce dépôt contient un ensemble d'applications et de pages web modulaires. Les i
 - Un overlay de débogage activé par `?debug=1` capture tous les journaux console.
 
 
+## Page d'accueil C2R Design
+
+- Fichier `index.html` associé à `css/landing.css` pour une landing page responsive.
+- La même mise en page est intégrée dans `os.html` via la section `#page-home` et un conteneur `.landing-page` pour bénéficier de la barre latérale.
+- Palette sombre : fond noir, texte blanc, accent rouge #ff1f1f.
+- Police Montserrat pour l'ensemble des textes.
+- Structure verticale mobile-first (ratio 9:16) avec animations légères au défilement.
+- Boutons reliant l'interface principale `#store` et la section Contact (`#contact`).
+- La section **Apprentissage et accompagnement** détaille l'automatisation avec Lya, l'intégration de l'IA en entreprise, la chaîne de production et le design augmenté.
+
 ## Plateforme d'echecs moderne
 
 Un projet complet de jeu d'echecs en ligne est installe dans les dossiers racines `client`, `server`, `ai` et `db`. Il utilise React, Node.js, PostgreSQL et Docker. Consultez `docs/chess-platform/README.md` pour le detail du lancement.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,19 @@
 
 Mini OS modulaire basé sur HTML/CSS/JS.
 
-Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référence directement `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css`.
+## Page d'accueil C2R Design
+
+Le fichier `index.html` propose une landing page responsive présentant les services du studio (créativité IA, automatisation, formations et web apps). Elle adopte un thème sombre (fond noir, texte blanc, accent rouge #ff1f1f) et la police Montserrat. Les boutons mènent directement à l'interface principale `os.html` pour accéder au Store et au formulaire de contact. Cette même vitrine est intégrée comme section d'accueil dans `os.html` afin de bénéficier de la barre latérale.
+
+La section **Apprentissage et accompagnement** présente notamment l'automatisation avec Lya, l'intégration de l'IA en entreprise, la chaîne de production et le design augmenté.
+
+
+Les icônes Font Awesome sont chargées via CDN. Les fichiers `index.html` et `os.html` référencent directement `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css`.
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - La liste des pop-ups indispensables figure dans [`docs/popup-readme.md`](docs/popup-readme.md).
-- Une section **Contact** intégrée dans `index.html` permet d'envoyer un message à `contact@c2ros.com`.
+- Une section **Contact** intégrée dans `os.html` permet d'envoyer un message à `contact@c2ros.com`.
 - La documentation de cette section se trouve dans [`docs/contact-readme.md`](docs/contact-readme.md).
 - Des fichiers `AGENTS.md` définissent les directives à suivre pour chaque page et chaque application. Consultez-les avant toute modification.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,19 @@
 # 📝 C2R OS - Journal des modifications
+## [1.1.39] - 2025-08-10 "HomeLanding"
+
+### 🏠 Accueil unifié
+- La page vitrine est intégrée dans `os.html` via la section `#page-home` et conserve la barre latérale.
+- `css/landing.css` est désormais limité au conteneur `.landing-page` pour éviter tout conflit de style.
+- La section Formations détaille l'automatisation avec Lya, l'intégration de l'IA en entreprise, la chaîne de production et le design augmenté.
+
+## [1.1.38] - 2025-08-10 "LandingMain"
+
+### 🏠 Vitrine principale
+- `accueil.html` devient `index.html` pour servir de page vitrine.
+- L'ancien `index.html` est renommé `os.html`.
+- Les liens de la vitrine redirigent vers `os.html#store` et `os.html#contact`.
+- Le manifeste PWA démarre désormais sur `os.html`.
+
 ## [1.1.37] - 2025-08-09 "MountFlag"
 
 ### ♟️ Correctifs Échecs Pro
@@ -336,7 +351,8 @@
 
 ```
 c2rOS2/
-├── index.html                 # Page principale
+├── index.html                 # Page vitrine
+├── os.html                    # Interface principale
 ├── version.json              # Informations de version
 ├── changelog.md              # Ce fichier
 │

--- a/css/landing.css
+++ b/css/landing.css
@@ -1,0 +1,159 @@
+/* Thème principal pour la page d'accueil C2R Design */
+:root {
+    --accent: #ff1f1f;
+}
+
+.landing-page * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+.landing-page {
+    font-family: 'Montserrat', sans-serif;
+    background: #000;
+    color: #fff;
+    line-height: 1.6;
+    scroll-behavior: smooth;
+}
+
+/* Zone héro */
+.landing-page .hero {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 2rem 1rem;
+    opacity: 0;
+    animation: fadeInUp 0.8s ease forwards;
+}
+
+.landing-page .logo {
+    font-size: 3rem;
+    font-weight: 700;
+    letter-spacing: 0.2rem;
+    color: var(--accent);
+    margin-bottom: 1rem;
+}
+
+.landing-page .tagline {
+    font-size: 1.4rem;
+    margin-bottom: 2rem;
+}
+
+.landing-page .cta-buttons {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.landing-page .btn {
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background 0.3s, color 0.3s;
+}
+
+.landing-page .btn.primary {
+    background: var(--accent);
+    color: #fff;
+}
+
+.landing-page .btn.secondary {
+    border: 1px solid var(--accent);
+    color: var(--accent);
+}
+
+.landing-page .btn:hover {
+    filter: brightness(1.1);
+}
+
+/* Sections générales */
+.landing-page .section {
+    padding: 4rem 1rem;
+    text-align: center;
+    max-width: 800px;
+    margin: 0 auto;
+    opacity: 0;
+    animation: fadeInUp 0.8s ease both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 30%;
+}
+
+.landing-page .section h2 {
+    color: var(--accent);
+    margin-bottom: 1rem;
+}
+
+.landing-page .section ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 1rem;
+}
+
+.landing-page .section ul li {
+    margin: 0.5rem 0;
+}
+
+/* Galerie d'exemples IA */
+.landing-page .galerie {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 1rem;
+}
+
+.landing-page .galerie img {
+    width: 100%;
+    max-width: 300px;
+    border-radius: 8px;
+}
+
+/* Icônes d'automatisation */
+.landing-page .icones {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    font-size: 2rem;
+    margin-top: 1rem;
+}
+
+/* Pied de page */
+.landing-page footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    border-top: 1px solid #222;
+}
+
+.landing-page footer .social a {
+    color: #fff;
+    margin: 0 0.5rem;
+    font-size: 1.5rem;
+    transition: color 0.3s;
+}
+
+.landing-page footer .social a:hover {
+    color: var(--accent);
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(40px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (min-width: 768px) {
+    .landing-page .tagline {
+        font-size: 2rem;
+    }
+}

--- a/docs/contact-readme.md
+++ b/docs/contact-readme.md
@@ -1,6 +1,6 @@
 # Section Contact
 
-La section `Contact` est intégrée au fichier `index.html` et permet de joindre l'équipe C2R OS.
+La section `Contact` est intégrée au fichier `os.html` et permet de joindre l'équipe C2R OS.
 
 Elle affiche l'adresse `contact@c2ros.com` et propose un formulaire avec les champs **Nom**, **E-mail** et **Message**. Le formulaire utilise la méthode POST et peut être relié à un service de traitement.
 

--- a/index.html
+++ b/index.html
@@ -3,463 +3,93 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="manifest" href="manifest.webmanifest">
-    <title>C2R OS - Système Modulaire</title>
-    <link rel="stylesheet" href="css/reset.css">
-    <link rel="stylesheet" href="css/global.css">
-    <link rel="stylesheet" href="css/layout.css">
-    <link rel="stylesheet" href="css/apps.css">
-    <link rel="stylesheet" href="css/notifications.css">
-    <link rel="stylesheet" href="css/sidebar-c2r.css">
-    <link rel="stylesheet" href="css/bottom-nav.css">
-    <link rel="stylesheet" href="css/theme.css">
-    <link rel="stylesheet" href="css/icons.css">
+    <title>C2R Design – Studio IA</title>
+    <!-- Police Montserrat -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+    <!-- Icônes Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/store-dark.css">
+    <!-- Feuille de style principale -->
+    <link rel="stylesheet" href="css/landing.css">
 </head>
-<body class="theme-dark">
-    <!-- Navigation latérale -->
-    <nav class="sidebar sidebar-c2r" id="sidebar">
-        <div class="sidebar-header">
-            <button class="sidebar-toggle mobile-only" id="sidebar-toggle" aria-label="Fermer le menu">
-                <span>&times;</span>
-            </button>
+<body class="landing-page">
+    <!-- Hero / En-tête principal -->
+    <header class="hero">
+        <div class="logo">C2R Design</div>
+        <p class="tagline">Studio de création propulsé par l’intelligence artificielle</p>
+        <div class="cta-buttons">
+            <a href="os.html#store" class="btn primary">Voir les démos</a>
+            <a href="os.html#contact" class="btn secondary">Contactez-moi</a>
         </div>
-        
-        <ul class="nav-menu">
-            <li class="nav-item">
-                <a href="#home" class="nav-link active" data-page="home" aria-label="Accueil">
-                    <span class="app-icon" data-icon="home"></span>
-                    <span class="nav-text">Accueil</span>
-                </a>
-            </li>
-            <li class="nav-item">
-                <a href="#store" class="nav-link" data-page="store" aria-label="Store d'applications">
-                    <span class="app-icon" data-icon="store"></span>
-                    <span class="nav-text">Store</span>
-                </a>
-            </li>
-            <li class="nav-item">
-                <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil utilisateur">
-                    <span class="app-icon" data-icon="profile"></span>
-                    <span class="nav-text">Profil</span>
-                </a>
-            </li>
-            <li class="nav-item">
-                <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
-                    <span class="app-icon" data-icon="mail"></span>
-                    <span class="nav-text">Contact</span>
-                </a>
-            </li>
-            <li class="nav-item admin-only" style="display: none;">
-                <a href="#admin" class="nav-link" data-page="admin" aria-label="Configuration administrateur">
-                    <span class="app-icon" data-icon="admin"></span>
-                    <span class="nav-text">Config</span>
-                </a>
-            </li>
+    </header>
+
+    <!-- Section À propos -->
+    <section id="apropos" class="section">
+        <h2>À propos</h2>
+        <p>C2R Design accompagne les entreprises et les agences en mêlant créativité, automatisation et innovation. Notre mission : transformer vos idées en expériences numériques percutantes.</p>
+    </section>
+
+    <!-- Section Créativité IA -->
+    <section id="creativite" class="section">
+        <h2>Créativité générée par IA</h2>
+        <ul>
+            <li>Génération d’images avec Luma Dream Machine</li>
+            <li>Montage vidéo pour les réseaux sociaux</li>
+            <li>Contenu TikTok sur mesure</li>
         </ul>
-
-        <!-- Section Applications Installées -->
-        <div class="sidebar-section user-only" style="display: none;">
-            <div class="sidebar-apps" id="sidebar-apps">
-                <!-- Applications installées -->
-            </div>
+        <div class="galerie">
+            <img src="https://via.placeholder.com/300x200?text=Visuel+IA+1" alt="Exemple IA 1">
+            <img src="https://via.placeholder.com/300x200?text=Visuel+IA+2" alt="Exemple IA 2">
+            <img src="https://via.placeholder.com/300x200?text=Visuel+IA+3" alt="Exemple IA 3">
         </div>
+    </section>
 
-        <div class="sidebar-footer">
-            <button class="btn-logout" id="logout-btn" aria-label="Se déconnecter">
-                <span class="app-icon" data-icon="signout"></span>
-                <span class="nav-text">Déconnexion</span>
-            </button>
+    <!-- Section Automatisation -->
+    <section id="automatisation" class="section">
+        <h2>Automatisation intelligente</h2>
+        <ul>
+            <li>Bots sur mesure</li>
+            <li>Workflows n8n et intégrations API</li>
+            <li>Automatisation des réseaux sociaux</li>
+        </ul>
+        <div class="icones">
+            <i class="fas fa-robot" aria-hidden="true"></i>
+            <i class="fas fa-diagram-project" aria-hidden="true"></i>
+            <i class="fas fa-share-nodes" aria-hidden="true"></i>
         </div>
-    </nav>
+    </section>
 
+    <!-- Section Formations IA -->
+    <section id="formations" class="section">
+        <h2>Apprentissage et accompagnement</h2>
+        <ul>
+            <li>Automatisation avec Lya</li>
+            <li>Intégration de l’IA en entreprise</li>
+            <li>Chaîne de production assistée par IA</li>
+            <li>Design augmenté par l’IA</li>
+        </ul>
+    </section>
 
-    <!-- Contenu principal -->
-    <main class="main-content">
-        <!-- Page d'accueil -->
-        <section id="page-home" class="page active">
-            <div class="welcome-card">
-                <div class="welcome-header">
-                    <h1>Bienvenue sur C2R OS</h1>
-                    <p class="system-version">C2R OS v1.1.33 – Build 2025-07-10</p>
-                    <p class="update-time text-small">Mis à jour le <span id="update-time"></span></p>
-                </div>
-                
-                <div class="welcome-content">
-                    <p id="welcome-message" class="welcome-text">
-                        Votre système modulaire d'applications est prêt à l'emploi.
-                    </p>
-                    
-                    <div class="quick-actions">
-                        <button class="btn btn-primary" data-page="store" aria-label="Accéder au store">
-                            <span data-icon="store"></span>
-                            Accéder au Store
-                        </button>
-                    </div>
+    <!-- Section Web & Apps -->
+    <section id="webapps" class="section">
+        <h2>Sites interactifs et applications</h2>
+        <p>Prototypes d’applications, interfaces dynamiques et outils sur mesure. Tout est fait sur mesure pour vos besoins.</p>
+        <a href="os.html#store" class="btn primary">Voir les prototypes</a>
+    </section>
 
-                    <div class="info-tiles">
-                        <a href="#store" data-page="store" class="card info-tile">
-                            <span data-icon="store"></span>
-                            <h3>Installez des applications IA et services</h3>
-                            <p>Explorez le Store pour trouver des intelligences artificielles, des formations ou des services. Les applications installées apparaissent ensuite dans la barre de navigation.</p>
-                        </a>
-                        <a href="#profile" data-page="profile" class="card info-tile">
-                            <span data-icon="profile"></span>
-                            <h3>Options du profil</h3>
-                            <p>Activez ou désactivez les notifications, changez de thème et déplacez la barre de navigation.</p>
-                        </a>
-                        <div class="card info-tile" id="install-tile" style="display:none;">
-                            <span data-icon="download"></span>
-                            <h3>Installer C2R OS</h3>
-                            <p>Ajoutez l'application sur votre smartphone en mode PWA pour un accès direct.</p>
-                            <button id="install-btn" class="btn btn-primary">Installer</button>
-                        </div>
-                        <a href="#store" data-page="store" class="card info-tile">
-                            <span data-icon="info"></span>
-                            <h3>Infos sur les applications</h3>
-                            <p>Découvrez les différents types d'applications disponibles et accédez directement au catalogue.</p>
-                        </a>
-                        <div class="card info-tile" id="changelog-tile">
-                            <span data-icon="history"></span>
-                            <h3>Dernières modifications</h3>
-                            <ul id="changelog-list" class="changelog-list"></ul>
-                        </div>
-                    </div>
+    <!-- Section Finale CTA -->
+    <section id="cta" class="section">
+        <h2>Discutons de votre projet</h2>
+        <a href="os.html#contact" class="btn primary">Contactez-moi</a>
+    </section>
 
-                    <div id="daily-tip" class="daily-tip">
-                        <h3><span data-icon="idea"></span> Conseil du jour</h3>
-                        <p>Explorez les nouvelles applications disponibles dans le Store pour enrichir votre expérience.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Page Store -->
-        <section id="page-store" class="page">
-            <div class="page-header">
-                <h1>Store d'Applications</h1>
-                <div class="store-controls">
-                    <div class="search-container">
-                        <input type="text" id="search-input" placeholder="Rechercher une application..." aria-label="Rechercher une application">
-                        <span class="search-icon" data-icon="search"></span>
-                    </div>
-                    <select id="sort-select" aria-label="Trier les applications">
-                        <option value="name">Nom</option>
-                        <option value="installed">Installées</option>
-                        <option value="date">Date</option>
-                        <option value="type">Type</option>
-                    </select>
-                    <select id="type-filter" aria-label="Filtrer par type">
-                        <option value="all">Tous</option>
-                        <option value="application">Applications</option>
-                        <option value="information">Informations</option>
-                        <option value="service">Services</option>
-                        <option value="formation">Formations</option>
-                    </select>
-                </div>
-            </div>
-            
-            <div class="store-container">
-                <div class="apps-grid" id="apps-grid">
-                    <!-- Applications générées dynamiquement -->
-                </div>
-            </div>
-        </section>
-
-        <!-- Page Profil -->
-        <section id="page-profile" class="page">
-            <div class="page-header">
-                <h1>Profil Utilisateur</h1>
-            </div>
-            
-            <div class="profile-content">
-                <div class="profile-info">
-                    <div class="user-details">
-                        <h3>Informations</h3>
-                        <p><strong>Email:</strong> <span id="user-email">utilisateur@c2ros.com</span></p>
-                        <p><strong>Rôle:</strong> <span id="user-role">Utilisateur</span></p>
-                    </div>
-                </div>
-                
-                <div class="installed-apps">
-                    <div id="installed-apps-list" class="apps-list">
-                        <!-- Liste générée dynamiquement -->
-                    </div>
-                </div>
-                
-                <div class="preferences">
-                    <h3>Préférences</h3>
-                    <div class="preference-group">
-                        <label class="switch-label">
-                            <span>Thème sombre</span>
-                            <label class="switch">
-                                <input type="checkbox" id="theme-toggle" checked>
-                                <span class="slider"></span>
-                            </label>
-                        </label>
-                    </div>
-                    
-                    <div class="preference-group">
-                        <label class="switch-label">
-                            <span>Afficher message d'accueil</span>
-                            <label class="switch">
-                                <input type="checkbox" id="welcome-toggle" checked>
-                                <span class="slider"></span>
-                            </label>
-                        </label>
-                    </div>
-                    
-                    <div class="preference-group">
-                        <label class="switch-label">
-                            <span>Barre latérale à droite</span>
-                            <label class="switch">
-                                <input type="checkbox" id="sidebar-position-toggle">
-                                <span class="slider"></span>
-                            </label>
-                        </label>
-                    </div>
-
-                    <div class="preference-group">
-                        <label class="switch-label">
-                            <span>Désactiver les pop-ups d'information</span>
-                            <label class="switch">
-                                <input type="checkbox" id="info-popups-toggle">
-                                <span class="slider"></span>
-                            </label>
-                        </label>
-                    </div>
-
-                    <button class="btn btn-secondary" id="clear-cache-user" aria-label="Vider le cache">
-                        Vider le cache
-                    </button>
-                    <button class="btn btn-primary" id="pwa-update" aria-label="Mise à jour">
-                        Mise à jour
-                    </button>
-                    <button class="btn btn-primary" id="back-admin-btn" style="display:none;" aria-label="Retour administrateur">
-                        Retour Admin
-                    </button>
-                    <button class="btn btn-secondary btn-logout" id="logout-btn-profile" aria-label="Se déconnecter">
-                        Déconnexion
-                    </button>
-                </div>
-            </div>
-        </section>
-
-        <!-- Page Admin -->
-        <section id="page-admin" class="page">
-            <div class="page-header">
-                <h1>Configuration Administrateur</h1>
-            </div>
-            
-            <div class="admin-content">
-                <div class="admin-section">
-                    <h3>Gestion des Utilisateurs</h3>
-                    <button class="btn btn-primary" id="add-user-btn" aria-label="Ajouter un utilisateur">
-                        Ajouter un utilisateur
-                    </button>
-                    <div class="users-table">
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Email</th>
-                                    <th>Nom d'utilisateur</th>
-                                    <th>Rôle</th>
-                                    <th>Dernière connexion</th>
-                                    <th>Hash mot de passe</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody id="users-table-body">
-                                <!-- Utilisateurs générés dynamiquement -->
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                
-                <div class="admin-section">
-                    <h3>Statistiques Système</h3>
-                    <div class="stats-grid">
-                        <div class="stat-card">
-                            <h4>Utilisateurs actifs</h4>
-                            <p class="stat-value" id="active-users">12</p>
-                        </div>
-                        <div class="stat-card">
-                            <h4>Applications installées</h4>
-                            <p class="stat-value" id="total-installations">47</p>
-                        </div>
-                        <div class="stat-card">
-                            <h4>Dernière mise à jour</h4>
-                            <p class="stat-value" id="last-update">10/07/2025</p>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="admin-section">
-                    <h3>Actions Système</h3>
-                    <div class="system-actions">
-                        <button class="btn btn-danger" id="reset-system" aria-label="Réinitialiser le système">
-                            <span data-icon="refresh"></span>
-                            Réinitialiser Système
-                        </button>
-                    </div>
-                </div>
-                
-                <details class="advanced-section">
-                    <summary>Options Avancées</summary>
-                    <div class="advanced-content">
-                        <h4>Logs Système</h4>
-                        <div class="logs-container">
-                            <pre id="system-logs">Chargement des logs...</pre>
-                        </div>
-                        <button class="btn btn-secondary" id="clear-cache" aria-label="Vider le cache">
-                            Vider le Cache
-                        </button>
-                    </div>
-                </details>
-            </div>
-        </section>
-
-        <!-- Page Contact -->
-        <section id="page-contact" class="page">
-            <div class="page-header">
-                <h1>Contact</h1>
-            </div>
-
-            <form id="contact-form" class="contact-form">
-                <div class="form-group">
-                    <label for="contact-name">Nom</label>
-                    <input type="text" id="contact-name" required>
-                </div>
-                <div class="form-group">
-                    <label for="contact-email">E-mail</label>
-                    <input type="email" id="contact-email" required>
-                </div>
-                <div class="form-group">
-                    <label for="contact-message">Message</label>
-                    <textarea id="contact-message" required></textarea>
-                </div>
-                <button type="submit" class="btn btn-primary">Envoyer</button>
-            </form>
-            <p class="text-small">Vous pouvez aussi nous écrire à <a href="mailto:contact@c2ros.com">contact@c2ros.com</a>.</p>
-        </section>
-    </main>
-
-    <!-- Barre de navigation mobile -->
-    <nav class="bottom-nav mobile-only">
-        <a href="#home" class="nav-link" data-page="home" aria-label="Accueil">
-            <span class="app-icon" data-icon="home"></span>
-        </a>
-        <a href="#store" class="nav-link" data-page="store" aria-label="Store">
-            <span class="app-icon" data-icon="store"></span>
-        </a>
-        <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil">
-            <span class="app-icon" data-icon="profile"></span>
-        </a>
-        <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
-            <span class="app-icon" data-icon="mail"></span>
-        </a>
-        <a href="#admin" class="nav-link admin-only" data-page="admin" aria-label="Configuration" style="display: none;">
-            <span class="app-icon" data-icon="admin"></span>
-        </a>
-        <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
-            <span class="app-icon" data-icon="list"></span>
-        </button>
-    </nav>
-
-    <div class="mobile-apps-dropdown" id="mobile-apps-dropdown">
-        <div class="mobile-apps-list" id="mobile-apps-list"></div>
-    </div>
-
-    <!-- Overlay mobile -->
-    <div class="overlay" id="overlay"></div>
-
-    <!-- Modales de connexion/inscription -->
-    <div class="modal" id="auth-modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 id="modal-title">Connexion à C2R OS</h2>
-                <button class="modal-close" id="modal-close">&times;</button>
-            </div>
-            
-            <!-- Formulaire de connexion -->
-            <form id="login-form" class="auth-form">
-                <div class="form-group">
-                    <label for="login-email">Email</label>
-                    <input type="email" id="login-email" required>
-                </div>
-                <div class="form-group">
-                    <label for="login-password">Mot de passe</label>
-                    <input type="password" id="login-password" required>
-                </div>
-                <button type="submit" class="btn btn-primary">Se connecter</button>
-                <p class="auth-switch">
-                    Pas de compte ? <a href="#" id="show-register">S'inscrire</a>
-                </p>
-            </form>
-            
-            <!-- Formulaire d'inscription -->
-            <form id="register-form" class="auth-form" style="display: none;">
-                <div class="form-group">
-                    <label for="register-email">Email</label>
-                    <input type="email" id="register-email" required>
-                </div>
-                <div class="form-group">
-                    <label for="register-username">Nom d'utilisateur</label>
-                    <input type="text" id="register-username" required>
-                </div>
-                <div class="form-group">
-                    <label for="register-password">Mot de passe</label>
-                    <input type="password" id="register-password" required minlength="6">
-                </div>
-                <div class="form-group">
-                    <label for="register-confirm">Confirmer mot de passe</label>
-                    <input type="password" id="register-confirm" required>
-                </div>
-                <button type="submit" class="btn btn-primary">S'inscrire</button>
-                <p class="auth-switch">
-                    Déjà un compte ? <a href="#" id="show-login">Se connecter</a>
-                </p>
-            </form>
+    <!-- Pied de page -->
+    <footer>
+        <div class="social">
+            <a href="https://www.tiktok.com" aria-label="TikTok"><i class="fab fa-tiktok"></i></a>
+            <a href="https://t.me" aria-label="Telegram"><i class="fab fa-telegram"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
         </div>
-    </div>
-
-    <!-- Section applications installées dans sidebar -->
-    <div class="installed-apps-sidebar" id="installed-apps-sidebar">
-        <div class="installed-apps-list" id="sidebar-apps-list">
-            <!-- Applications installées générées dynamiquement -->
-        </div>
-    </div>
-
-
-    <!-- Chargement des modules C2R OS dans l'ordre de dépendance -->
-    <script src="js/modules/core/config.js"></script>
-    <script src="js/modules/ui/icon-manager.js"></script>
-    <script src="js/modules/user/user-core.js"></script>
-    <script src="js/modules/app/app-core.js"></script>
-    <script src="js/modules/ui/ui-core.js"></script>
-    <script src="js/modules/profile/profile-system.js"></script>
-    <script src="js/modules/system/system-integration.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-
-    <!-- Point d'entrée principal -->
-    <!-- Correctif mobile pour le menu hamburger -->
-    <script src="js/mobile-fix.js"></script>
-    <script src="js/bottom-nav.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            IconManager.inject();
-        });
-        window.addEventListener('c2rosReady', () => {
-            IconManager.startAutoInject();
-        });
-    </script>
-    <script src="js/main.js"></script>
+        <p>© 2025 – C2R Design, tous droits réservés.</p>
+    </footer>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "C2R OS",
   "short_name": "C2R",
-  "start_url": "./index.html",
+  "start_url": "./os.html",
   "display": "standalone",
   "background_color": "#0D0D12",
   "theme_color": "#0D0D12"

--- a/os.html
+++ b/os.html
@@ -1,0 +1,494 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="manifest" href="manifest.webmanifest">
+    <title>C2R OS - Système Modulaire</title>
+    <link rel="stylesheet" href="css/reset.css">
+    <link rel="stylesheet" href="css/global.css">
+    <link rel="stylesheet" href="css/layout.css">
+    <link rel="stylesheet" href="css/apps.css">
+    <link rel="stylesheet" href="css/notifications.css">
+    <link rel="stylesheet" href="css/sidebar-c2r.css">
+    <link rel="stylesheet" href="css/bottom-nav.css">
+    <link rel="stylesheet" href="css/theme.css">
+    <link rel="stylesheet" href="css/icons.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/store-dark.css">
+    <link rel="stylesheet" href="css/landing.css">
+</head>
+<body class="theme-dark">
+    <!-- Navigation latérale -->
+    <nav class="sidebar sidebar-c2r" id="sidebar">
+        <div class="sidebar-header">
+            <button class="sidebar-toggle mobile-only" id="sidebar-toggle" aria-label="Fermer le menu">
+                <span>&times;</span>
+            </button>
+        </div>
+        
+        <ul class="nav-menu">
+            <li class="nav-item">
+                <a href="#home" class="nav-link active" data-page="home" aria-label="Accueil">
+                    <span class="app-icon" data-icon="home"></span>
+                    <span class="nav-text">Accueil</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="#store" class="nav-link" data-page="store" aria-label="Store d'applications">
+                    <span class="app-icon" data-icon="store"></span>
+                    <span class="nav-text">Store</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil utilisateur">
+                    <span class="app-icon" data-icon="profile"></span>
+                    <span class="nav-text">Profil</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
+                    <span class="app-icon" data-icon="mail"></span>
+                    <span class="nav-text">Contact</span>
+                </a>
+            </li>
+            <li class="nav-item admin-only" style="display: none;">
+                <a href="#admin" class="nav-link" data-page="admin" aria-label="Configuration administrateur">
+                    <span class="app-icon" data-icon="admin"></span>
+                    <span class="nav-text">Config</span>
+                </a>
+            </li>
+        </ul>
+
+        <!-- Section Applications Installées -->
+        <div class="sidebar-section user-only" style="display: none;">
+            <div class="sidebar-apps" id="sidebar-apps">
+                <!-- Applications installées -->
+            </div>
+        </div>
+
+        <div class="sidebar-footer">
+            <button class="btn-logout" id="logout-btn" aria-label="Se déconnecter">
+                <span class="app-icon" data-icon="signout"></span>
+                <span class="nav-text">Déconnexion</span>
+            </button>
+        </div>
+    </nav>
+
+
+    <!-- Contenu principal -->
+    <main class="main-content">
+        <!-- Page d'accueil -->
+        <!-- Page d'accueil / Vitrine -->
+        <section id="page-home" class="page active">
+            <div class="landing-page">
+                <!-- Hero / En-tête principal -->
+                <header class="hero">
+                    <div class="logo">C2R Design</div>
+                    <p class="tagline">Studio de création propulsé par l’intelligence artificielle</p>
+                    <div class="cta-buttons">
+                        <a href="#store" data-page="store" class="btn primary">Voir les démos</a>
+                        <a href="#contact" data-page="contact" class="btn secondary">Contactez-moi</a>
+                    </div>
+                </header>
+
+                <!-- Section À propos -->
+                <section id="apropos" class="section">
+                    <h2>À propos</h2>
+                    <p>C2R Design accompagne les entreprises et les agences en mêlant créativité, automatisation et innovation. Notre mission : transformer vos idées en expériences numériques percutantes.</p>
+                </section>
+
+                <!-- Section Créativité IA -->
+                <section id="creativite" class="section">
+                    <h2>Créativité générée par IA</h2>
+                    <ul>
+                        <li>Génération d’images avec Luma Dream Machine</li>
+                        <li>Montage vidéo pour les réseaux sociaux</li>
+                        <li>Contenu TikTok sur mesure</li>
+                    </ul>
+                    <div class="galerie">
+                        <img src="https://via.placeholder.com/300x200?text=Visuel+IA+1" alt="Exemple IA 1">
+                        <img src="https://via.placeholder.com/300x200?text=Visuel+IA+2" alt="Exemple IA 2">
+                        <img src="https://via.placeholder.com/300x200?text=Visuel+IA+3" alt="Exemple IA 3">
+                    </div>
+                </section>
+
+                <!-- Section Automatisation -->
+                <section id="automatisation" class="section">
+                    <h2>Automatisation intelligente</h2>
+                    <ul>
+                        <li>Bots sur mesure</li>
+                        <li>Workflows n8n et intégrations API</li>
+                        <li>Automatisation des réseaux sociaux</li>
+                    </ul>
+                    <div class="icones">
+                        <i class="fas fa-robot" aria-hidden="true"></i>
+                        <i class="fas fa-diagram-project" aria-hidden="true"></i>
+                        <i class="fas fa-share-nodes" aria-hidden="true"></i>
+                    </div>
+                </section>
+
+                <!-- Section Formations IA -->
+                <section id="formations" class="section">
+                    <h2>Apprentissage et accompagnement</h2>
+                    <ul>
+                        <li>Automatisation avec Lya</li>
+                        <li>Intégration de l’IA en entreprise</li>
+                        <li>Chaîne de production assistée par IA</li>
+                        <li>Design augmenté par l’IA</li>
+                    </ul>
+                </section>
+
+                <!-- Section Web & Apps -->
+                <section id="webapps" class="section">
+                    <h2>Sites interactifs et applications</h2>
+                    <p>Prototypes d’applications, interfaces dynamiques et outils sur mesure. Tout est fait sur mesure pour vos besoins.</p>
+                    <a href="#store" data-page="store" class="btn primary">Voir les prototypes</a>
+                </section>
+
+                <!-- Section Finale CTA -->
+                <section id="cta" class="section">
+                    <h2>Discutons de votre projet</h2>
+                    <a href="#contact" data-page="contact" class="btn primary">Contactez-moi</a>
+                </section>
+
+                <!-- Pied de page -->
+                <footer>
+                    <div class="social">
+                        <a href="https://www.tiktok.com" aria-label="TikTok"><i class="fab fa-tiktok"></i></a>
+                        <a href="https://t.me" aria-label="Telegram"><i class="fab fa-telegram"></i></a>
+                        <a href="https://www.instagram.com" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                    </div>
+                    <p>© 2025 – C2R Design, tous droits réservés.</p>
+                </footer>
+            </div>
+        </section>
+
+        <!-- Page Store -->
+        <section id="page-store" class="page">
+            <div class="page-header">
+                <h1>Store d'Applications</h1>
+                <div class="store-controls">
+                    <div class="search-container">
+                        <input type="text" id="search-input" placeholder="Rechercher une application..." aria-label="Rechercher une application">
+                        <span class="search-icon" data-icon="search"></span>
+                    </div>
+                    <select id="sort-select" aria-label="Trier les applications">
+                        <option value="name">Nom</option>
+                        <option value="installed">Installées</option>
+                        <option value="date">Date</option>
+                        <option value="type">Type</option>
+                    </select>
+                    <select id="type-filter" aria-label="Filtrer par type">
+                        <option value="all">Tous</option>
+                        <option value="application">Applications</option>
+                        <option value="information">Informations</option>
+                        <option value="service">Services</option>
+                        <option value="formation">Formations</option>
+                    </select>
+                </div>
+            </div>
+            
+            <div class="store-container">
+                <div class="apps-grid" id="apps-grid">
+                    <!-- Applications générées dynamiquement -->
+                </div>
+            </div>
+        </section>
+
+        <!-- Page Profil -->
+        <section id="page-profile" class="page">
+            <div class="page-header">
+                <h1>Profil Utilisateur</h1>
+            </div>
+            
+            <div class="profile-content">
+                <div class="profile-info">
+                    <div class="user-details">
+                        <h3>Informations</h3>
+                        <p><strong>Email:</strong> <span id="user-email">utilisateur@c2ros.com</span></p>
+                        <p><strong>Rôle:</strong> <span id="user-role">Utilisateur</span></p>
+                    </div>
+                </div>
+                
+                <div class="installed-apps">
+                    <div id="installed-apps-list" class="apps-list">
+                        <!-- Liste générée dynamiquement -->
+                    </div>
+                </div>
+                
+                <div class="preferences">
+                    <h3>Préférences</h3>
+                    <div class="preference-group">
+                        <label class="switch-label">
+                            <span>Thème sombre</span>
+                            <label class="switch">
+                                <input type="checkbox" id="theme-toggle" checked>
+                                <span class="slider"></span>
+                            </label>
+                        </label>
+                    </div>
+                    
+                    <div class="preference-group">
+                        <label class="switch-label">
+                            <span>Afficher message d'accueil</span>
+                            <label class="switch">
+                                <input type="checkbox" id="welcome-toggle" checked>
+                                <span class="slider"></span>
+                            </label>
+                        </label>
+                    </div>
+                    
+                    <div class="preference-group">
+                        <label class="switch-label">
+                            <span>Barre latérale à droite</span>
+                            <label class="switch">
+                                <input type="checkbox" id="sidebar-position-toggle">
+                                <span class="slider"></span>
+                            </label>
+                        </label>
+                    </div>
+
+                    <div class="preference-group">
+                        <label class="switch-label">
+                            <span>Désactiver les pop-ups d'information</span>
+                            <label class="switch">
+                                <input type="checkbox" id="info-popups-toggle">
+                                <span class="slider"></span>
+                            </label>
+                        </label>
+                    </div>
+
+                    <button class="btn btn-secondary" id="clear-cache-user" aria-label="Vider le cache">
+                        Vider le cache
+                    </button>
+                    <button class="btn btn-primary" id="pwa-update" aria-label="Mise à jour">
+                        Mise à jour
+                    </button>
+                    <button class="btn btn-primary" id="back-admin-btn" style="display:none;" aria-label="Retour administrateur">
+                        Retour Admin
+                    </button>
+                    <button class="btn btn-secondary btn-logout" id="logout-btn-profile" aria-label="Se déconnecter">
+                        Déconnexion
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <!-- Page Admin -->
+        <section id="page-admin" class="page">
+            <div class="page-header">
+                <h1>Configuration Administrateur</h1>
+            </div>
+            
+            <div class="admin-content">
+                <div class="admin-section">
+                    <h3>Gestion des Utilisateurs</h3>
+                    <button class="btn btn-primary" id="add-user-btn" aria-label="Ajouter un utilisateur">
+                        Ajouter un utilisateur
+                    </button>
+                    <div class="users-table">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Email</th>
+                                    <th>Nom d'utilisateur</th>
+                                    <th>Rôle</th>
+                                    <th>Dernière connexion</th>
+                                    <th>Hash mot de passe</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="users-table-body">
+                                <!-- Utilisateurs générés dynamiquement -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                
+                <div class="admin-section">
+                    <h3>Statistiques Système</h3>
+                    <div class="stats-grid">
+                        <div class="stat-card">
+                            <h4>Utilisateurs actifs</h4>
+                            <p class="stat-value" id="active-users">12</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Applications installées</h4>
+                            <p class="stat-value" id="total-installations">47</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Dernière mise à jour</h4>
+                            <p class="stat-value" id="last-update">10/07/2025</p>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="admin-section">
+                    <h3>Actions Système</h3>
+                    <div class="system-actions">
+                        <button class="btn btn-danger" id="reset-system" aria-label="Réinitialiser le système">
+                            <span data-icon="refresh"></span>
+                            Réinitialiser Système
+                        </button>
+                    </div>
+                </div>
+                
+                <details class="advanced-section">
+                    <summary>Options Avancées</summary>
+                    <div class="advanced-content">
+                        <h4>Logs Système</h4>
+                        <div class="logs-container">
+                            <pre id="system-logs">Chargement des logs...</pre>
+                        </div>
+                        <button class="btn btn-secondary" id="clear-cache" aria-label="Vider le cache">
+                            Vider le Cache
+                        </button>
+                    </div>
+                </details>
+            </div>
+        </section>
+
+        <!-- Page Contact -->
+        <section id="page-contact" class="page">
+            <div class="page-header">
+                <h1>Contact</h1>
+            </div>
+
+            <form id="contact-form" class="contact-form">
+                <div class="form-group">
+                    <label for="contact-name">Nom</label>
+                    <input type="text" id="contact-name" required>
+                </div>
+                <div class="form-group">
+                    <label for="contact-email">E-mail</label>
+                    <input type="email" id="contact-email" required>
+                </div>
+                <div class="form-group">
+                    <label for="contact-message">Message</label>
+                    <textarea id="contact-message" required></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary">Envoyer</button>
+            </form>
+            <p class="text-small">Vous pouvez aussi nous écrire à <a href="mailto:contact@c2ros.com">contact@c2ros.com</a>.</p>
+        </section>
+    </main>
+
+    <!-- Barre de navigation mobile -->
+    <nav class="bottom-nav mobile-only">
+        <a href="#home" class="nav-link" data-page="home" aria-label="Accueil">
+            <span class="app-icon" data-icon="home"></span>
+        </a>
+        <a href="#store" class="nav-link" data-page="store" aria-label="Store">
+            <span class="app-icon" data-icon="store"></span>
+        </a>
+        <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil">
+            <span class="app-icon" data-icon="profile"></span>
+        </a>
+        <a href="#contact" class="nav-link" data-page="contact" aria-label="Contact">
+            <span class="app-icon" data-icon="mail"></span>
+        </a>
+        <a href="#admin" class="nav-link admin-only" data-page="admin" aria-label="Configuration" style="display: none;">
+            <span class="app-icon" data-icon="admin"></span>
+        </a>
+        <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
+            <span class="app-icon" data-icon="list"></span>
+        </button>
+    </nav>
+
+    <div class="mobile-apps-dropdown" id="mobile-apps-dropdown">
+        <div class="mobile-apps-list" id="mobile-apps-list"></div>
+    </div>
+
+    <!-- Overlay mobile -->
+    <div class="overlay" id="overlay"></div>
+
+    <!-- Modales de connexion/inscription -->
+    <div class="modal" id="auth-modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="modal-title">Connexion à C2R OS</h2>
+                <button class="modal-close" id="modal-close">&times;</button>
+            </div>
+            
+            <!-- Formulaire de connexion -->
+            <form id="login-form" class="auth-form">
+                <div class="form-group">
+                    <label for="login-email">Email</label>
+                    <input type="email" id="login-email" required>
+                </div>
+                <div class="form-group">
+                    <label for="login-password">Mot de passe</label>
+                    <input type="password" id="login-password" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Se connecter</button>
+                <p class="auth-switch">
+                    Pas de compte ? <a href="#" id="show-register">S'inscrire</a>
+                </p>
+            </form>
+            
+            <!-- Formulaire d'inscription -->
+            <form id="register-form" class="auth-form" style="display: none;">
+                <div class="form-group">
+                    <label for="register-email">Email</label>
+                    <input type="email" id="register-email" required>
+                </div>
+                <div class="form-group">
+                    <label for="register-username">Nom d'utilisateur</label>
+                    <input type="text" id="register-username" required>
+                </div>
+                <div class="form-group">
+                    <label for="register-password">Mot de passe</label>
+                    <input type="password" id="register-password" required minlength="6">
+                </div>
+                <div class="form-group">
+                    <label for="register-confirm">Confirmer mot de passe</label>
+                    <input type="password" id="register-confirm" required>
+                </div>
+                <button type="submit" class="btn btn-primary">S'inscrire</button>
+                <p class="auth-switch">
+                    Déjà un compte ? <a href="#" id="show-login">Se connecter</a>
+                </p>
+            </form>
+        </div>
+    </div>
+
+    <!-- Section applications installées dans sidebar -->
+    <div class="installed-apps-sidebar" id="installed-apps-sidebar">
+        <div class="installed-apps-list" id="sidebar-apps-list">
+            <!-- Applications installées générées dynamiquement -->
+        </div>
+    </div>
+
+
+    <!-- Chargement des modules C2R OS dans l'ordre de dépendance -->
+    <script src="js/modules/core/config.js"></script>
+    <script src="js/modules/ui/icon-manager.js"></script>
+    <script src="js/modules/user/user-core.js"></script>
+    <script src="js/modules/app/app-core.js"></script>
+    <script src="js/modules/ui/ui-core.js"></script>
+    <script src="js/modules/profile/profile-system.js"></script>
+    <script src="js/modules/system/system-integration.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+
+    <!-- Point d'entrée principal -->
+    <!-- Correctif mobile pour le menu hamburger -->
+    <script src="js/mobile-fix.js"></script>
+    <script src="js/bottom-nav.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            IconManager.inject();
+        });
+        window.addEventListener('c2rosReady', () => {
+            IconManager.startAutoInject();
+        });
+    </script>
+    <script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Résumé
- Refonte de `css/landing.css` pour n'agir que sur `.landing-page`
- Intégration de la landing page comme section Accueil dans `os.html`
- Mise à jour de la section Formations (automatisation avec Lya, intégration IA en entreprise, production et design)

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aacfeb16bc832e804d34b00136062d